### PR TITLE
Change pluralization to pluralize lib for better defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "hyped",
-  "version": "0.1.0-6",
+  "version": "0.1.0-7",
   "description": "Hypermedia response generation engine",
   "main": "src/index.js",
   "dependencies": {
     "lodash": "^2.4.1",
     "parseurl": "^1.2.0",
-    "plural": "^0.1.6",
+    "pluralize": "^1.1.2",
     "qs": "^1.0.0",
     "request": "^2.47.0",
     "when": "^3.4.2"

--- a/spec/autohost.spec.js
+++ b/spec/autohost.spec.js
@@ -4,7 +4,7 @@ var model = require( "./model.js" );
 var request = require( "request" );
 
 var board1 = model.board1;
-var limit = 10;
+var limit = 15;
 
 describe( "with oldest version as default", function() {
 	var autohost = require( "autohost" );
@@ -949,6 +949,7 @@ describe( "with oldest version as default", function() {
 		it( "should get options", function() {
 			contentType.should.equal( "application/json" );
 			var json = JSON.parse( body );
+			delete json._links[ "ah:metrics" ];
 			json.should.eql( expectedOptions );
 		} );
 

--- a/spec/condition.spec.js
+++ b/spec/condition.spec.js
@@ -1,7 +1,7 @@
 var should = require( "should" ); // jshint ignore: line
 var HyperResource = require( "../src/hyperResource.js" );
 
-var limit = 2;
+var limit = 4;
 
 describe( "when filtering links by predicate", function() {
 	var resource = {

--- a/spec/hyperResource.spec.js
+++ b/spec/hyperResource.spec.js
@@ -29,13 +29,13 @@ describe( "Action links", function() {
 			it( "should build the urlCache correctly", function() {
 				urlCache.should.eql( {
 					parent: { url: "", tokens: [] },
-					child: { url: "/parent/{id}", tokens: [ 
-						{ original: "id", namespace: "", resource: "parent", property: "id", camel: "parentId" }
-					] },
+					child: { url: "/parent/{id}", tokens: [
+							{ original: "id", namespace: "", resource: "parent", property: "id", camel: "parentId" }
+						] },
 					grandChild: { url: "/parent/{id}/child/{child.id}", tokens: [
-						{ original: "id", namespace: "", resource: "parent", property: "id", camel: "parentId" },
-						{ original: "child.id", namespace: "", resource: "child", property: "id", camel: "childId" }
-					] }
+							{ original: "id", namespace: "", resource: "parent", property: "id", camel: "parentId" },
+							{ original: "child.id", namespace: "", resource: "child", property: "id", camel: "childId" }
+						] }
 				} );
 			} );
 
@@ -51,7 +51,7 @@ describe( "Action links", function() {
 				grandChild.should.equal( "/parent/1/child/2" );
 			} );
 		} );
-		
+
 		describe( "when creating action urls", function() {
 			var parent, child, grandChild, children, next;
 
@@ -152,7 +152,7 @@ describe( "Action links", function() {
 	} );
 
 	describe( "When rendering links from different actions", function() {
-		
+
 		describe( "when rendering an 'plain' action", function() {
 			var expected = { self: { href: "/parent/1", method: "GET" } };
 			var links;
@@ -196,7 +196,9 @@ describe( "Action links", function() {
 					id: 1
 				};
 				var fn = HyperResource.linkFn( resources );
-				links = fn( "parent", "children", model, "", undefined, function() { return false; } );
+				links = fn( "parent", "children", model, "", undefined, function() {
+					return false;
+				} );
 			} );
 
 			it( "should produce expected links", function() {
@@ -351,45 +353,45 @@ describe( "Action links", function() {
 							_origin: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
 							_resource: "grandChild",
 							_action: "self",
-							_links: { 
+							_links: {
 								self: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" } 
+								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
 							}
 						},
 						{ id: 2,
 							_origin: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
 							_resource: "grandChild",
 							_action: "self",
-							_links: { 
+							_links: {
 								self: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" } 
+								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
 							}
 						},
 						{ id: 3,
-							_origin: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" }, 
+							_origin: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
 							_resource: "grandChild",
 							_action: "self",
-							_links: { 
+							_links: {
 								self: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" } 
+								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
 							}
 						},
 						{ id: 4,
-							_origin: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" }, 
+							_origin: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
 							_resource: "grandChild",
 							_action: "self",
-							_links: { 
+							_links: {
 								self: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" } 
+								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
 							}
 						},
 						{ id: 5,
-							_origin: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" }, 
+							_origin: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
 							_resource: "grandChild",
 							_action: "self",
-							_links: { 
+							_links: {
 								self: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" } 
+								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
 							}
 						}
 					]
@@ -423,31 +425,31 @@ describe( "Action links", function() {
 	} );
 
 	describe( "when rendering options including children", function() {
-			var expected = {
-				_mediaTypes: [],
-				_versions: [ "1", "2" ],
-				_links: {
-					"parent:self": { href: "/parent/{id}", method: "GET", templated: true },
-					"parent:list": { href: "/parent", method: "GET" },
-					"parent:children": { href: "/parent/{id}/child", method: "GET", templated: true, parameters: {
+		var expected = {
+			_mediaTypes: [],
+			_versions: [ "1", "2" ],
+			_links: {
+				"parent:self": { href: "/parent/{id}", method: "GET", templated: true },
+				"parent:list": { href: "/parent", method: "GET" },
+				"parent:children": { href: "/parent/{id}/child", method: "GET", templated: true, parameters: {
 						size: { range: [ 1, 100 ] }
 					} },
-					"child:self": { href: "/parent/{parentId}/child/{id}", method: "GET", templated: true },
-					"grandChild:self": { href: "/parent/{parentId}/child/{childId}/grand/{id}", method: "GET", templated: true },
-					"grandChild:create": { href: "/parent/{parentId}/child/{childId}/grand", method: "POST", templated: true },
-					"grandChild:delete": { href: "/parent/{parentId}/child/{childId}/grand/{id}", method: "DELETE", templated: true }
-				}
-			};
-			var options;
+				"child:self": { href: "/parent/{parentId}/child/{id}", method: "GET", templated: true },
+				"grandChild:self": { href: "/parent/{parentId}/child/{childId}/grand/{id}", method: "GET", templated: true },
+				"grandChild:create": { href: "/parent/{parentId}/child/{childId}/grand", method: "POST", templated: true },
+				"grandChild:delete": { href: "/parent/{parentId}/child/{childId}/grand/{id}", method: "DELETE", templated: true }
+			}
+		};
+		var options;
 
-			before( function() {
-				var fn = HyperResource.optionsFn( resources );
-				options = fn();
-			} );
+		before( function() {
+			var fn = HyperResource.optionsFn( resources );
+			options = fn();
+		} );
 
-			it( "should render options correctly", function() {
-				options.should.eql( expected );
-			} );
+		it( "should render options correctly", function() {
+			options.should.eql( expected );
+		} );
 	} );
 
 	describe( "when rendering options excluding children", function() {
@@ -458,8 +460,8 @@ describe( "Action links", function() {
 				"parent:self": { href: "/parent/{id}", method: "GET", templated: true },
 				"parent:list": { href: "/parent", method: "GET" },
 				"parent:children": { href: "/parent/{id}/child", method: "GET", templated: true, parameters: {
-					size: { range: [ 1, 100 ] }
-				} }
+						size: { range: [ 1, 100 ] }
+					} }
 			}
 		};
 		var options;
@@ -489,7 +491,7 @@ describe( "Action links", function() {
 					_origin: { href: "/parent/1", method: "GET" },
 					_resource: "parent",
 					_action: "self",
-					_links: {	
+					_links: {
 						self: { href: "/parent/1", method: "GET" },
 						list: { href: "/parent", method: "GET" },
 						children: { href: "/parent/1/child", method: "GET", parameters: parameters }
@@ -503,7 +505,7 @@ describe( "Action links", function() {
 					_origin: { href: "/parent/2", method: "GET" },
 					_resource: "parent",
 					_action: "self",
-					_links: {	
+					_links: {
 						self: { href: "/parent/2", method: "GET" },
 						list: { href: "/parent", method: "GET" },
 						children: { href: "/parent/2/child", method: "GET", parameters: parameters }
@@ -524,7 +526,7 @@ describe( "Action links", function() {
 				title: "two",
 				description: "the second item",
 				children: [ {} ]
-			} 
+			}
 		];
 		var elapsed;
 
@@ -548,7 +550,7 @@ describe( "Action links", function() {
 	describe( "when rendering a list of resources from another resource", function() {
 		var expected = {
 			_origin: { href: "/parent/1/child", method: "GET" },
-			childs: [
+			children: [
 				{
 					id: 1,
 					parentId: 1,
@@ -557,7 +559,7 @@ describe( "Action links", function() {
 					_resource: "child",
 					_action: "self",
 					_origin: { href: "/parent/1/child/1", method: "GET" },
-					_links: {	
+					_links: {
 						self: { href: "/parent/1/child/1", method: "GET" },
 					}
 				},
@@ -569,7 +571,7 @@ describe( "Action links", function() {
 					_resource: "child",
 					_action: "self",
 					_origin: { href: "/parent/1/child/2", method: "GET" },
-					_links: {	
+					_links: {
 						self: { href: "/parent/1/child/2", method: "GET" },
 					}
 				}
@@ -588,7 +590,7 @@ describe( "Action links", function() {
 				parentId: 1,
 				title: "two",
 				description: "the second item"
-			} 
+			}
 		];
 		var elapsed;
 
@@ -618,7 +620,7 @@ describe( "Action links", function() {
 				var start = Date.now();
 				var tokens = url.getTokens( testUrl );
 				var halUrl = url.forHal( testUrl );
-				for( var i = 0; i < 1000; i ++ ) {
+				for (var i = 0; i < 1000; i++) {
 
 					urls.push( url.process( _.clone( tokens ), halUrl, { id: 1, childId: 2 }, "parent" ) );
 				}

--- a/src/halEngine.js
+++ b/src/halEngine.js
@@ -1,4 +1,4 @@
-function render( model ) { 
+function render( model ) {
 	return JSON.stringify( model );
 }
 

--- a/src/hyperResponse.js
+++ b/src/hyperResponse.js
@@ -1,5 +1,7 @@
 var HyperResponse = function( req, res, engine, hyperResource, contentType ) {
-	this._authCheck = req._checkPermission || function() { return true; };
+	this._authCheck = req._checkPermission || function() {
+		return true;
+	};
 	this._code = 200;
 	this._engine = engine;
 	this._hyperResource = hyperResource;
@@ -33,23 +35,25 @@ HyperResponse.prototype.status = function( code ) {
 };
 
 HyperResponse.prototype.render = function() {
-	if( this._engine ) {
+	if ( this._engine ) {
 		try {
-		var resource = this._req._resource;
-		var action = this._req._action;
-		var hypermedia = this._hyperResource( 
-			this._resource || resource,
-			this._action || action,
-			this._model,
-			"",
-			this._context,
-			this._originUrl,
-			this._originMethod
-		);
+			var resource = this._req._resource;
+			var action = this._req._action;
+			var hypermedia = this._hyperResource(
+				this._resource || resource,
+				this._action || action,
+				this._model,
+				"",
+				this._context,
+				this._originUrl,
+				this._originMethod
+			);
 
-		var body = this._engine( hypermedia );
-		this._res.set( "Content-Type", this._contentType ).status( this._code ).send( body );
-	} catch( e ) { console.log( e.stack ); }
+			var body = this._engine( hypermedia );
+			this._res.set( "Content-Type", this._contentType ).status( this._code ).send( body );
+		} catch (e) {
+			console.log( e.stack );
+		}
 	} else {
 		this._res.status( 415 ).send( "The requested media type '" + this._contentType + "' is not supported. Please see the OPTIONS at the api root to get a list of supported types." );
 	}

--- a/src/jsonEngine.js
+++ b/src/jsonEngine.js
@@ -1,7 +1,7 @@
 var _ = require( "lodash" );
 
 function handleEmbedded( target, model, preserveMetadata ) {
-	if( model._embedded ) {
+	if ( model._embedded ) {
 		_.each( model._embedded, function( embedded, property ) {
 			target[ property ] = _.isArray( embedded ) ? handleList( embedded, preserveMetadata ) : handleObject( embedded, preserveMetadata );
 		} );
@@ -25,7 +25,9 @@ function process( model, preserveMetadata ) {
 }
 
 function stripMetadata( model ) { // jshint ignore:line
-	return _.omit( model, function( val, key ) { return key.indexOf( "_" ) === 0; } );
+	return _.omit( model, function( val, key ) {
+		return key.indexOf( "_" ) === 0;
+	} );
 }
 
 module.exports = process;

--- a/src/urlTemplate.js
+++ b/src/urlTemplate.js
@@ -6,22 +6,22 @@ var expressReplace = /[:]replace/g; // jshint ignore:line
 var braceFind = /[{]([^}]*)[}]/g;
 var braceReplace = /[{]replace[}]/g;
 
-function camelCase ( token ) {
+function camelCase( token ) {
 	return camelize( token.resource, token.property );
 }
 
 function camelize( resource, property ) { // jshint ignore:line
-	return _.isEmpty( resource ) ? 
-			property :
-			resource + property[ 0 ].toUpperCase() + property.slice( 1 );	
+	return _.isEmpty( resource ) ?
+		property :
+		resource + property[ 0 ].toUpperCase() + property.slice( 1 );
 }
 
 function createUrl( url, data, resource ) {
-	if( isExpressStyle( url ) ) {
+	if ( isExpressStyle( url ) ) {
 		url = halStylePathVariables( url );
 	}
 	var tokens = getTokens( url );
-	if( tokens.length > 0 ) {
+	if ( tokens.length > 0 ) {
 		url = processTokens( tokens, url, data, resource );
 	}
 	return url;
@@ -30,7 +30,7 @@ function createUrl( url, data, resource ) {
 function expressStylePathVarialbes( url ) {
 	var match;
 	var expressUrl = url;
-	while( ( match = braceFind.exec( url ) ) ) {
+	while (( match = braceFind.exec( url ) )) {
 		expressUrl = expressUrl.replace( match[ 0 ], ":" + match[ 1 ] );
 	}
 	return expressUrl;
@@ -39,7 +39,7 @@ function expressStylePathVarialbes( url ) {
 function halStylePathVariables( url ) { // jshint ignore:line
 	var match;
 	var expressUrl = url;
-	while( ( match = expressFind.exec( url ) ) ) {
+	while (( match = expressFind.exec( url ) )) {
 		expressUrl = expressUrl.replace( match[ 0 ], "{" + match[ 1 ] + "}" );
 	}
 	return expressUrl;
@@ -49,7 +49,7 @@ function getTokens( url ) { // jshint ignore:line
 	var tokens = [];
 	var match, tokenName;
 	var pattern = isExpressStyle( url ) ? expressFind : braceFind;
-	while( ( match = pattern.exec( url ) ) ) {
+	while (( match = pattern.exec( url ) )) {
 		tokenName = match[ 1 ];
 		tokens.push( parseToken( tokenName ) );
 	}
@@ -61,11 +61,11 @@ function isExpressStyle( url ) { // jshint ignore:line
 	expressFind.lastIndex = 0;
 	return found;
 }
- 
+
 function parseRegex( regex ) {
 	return regex.match( /\/g$/ ) ?
-		new RegExp( regex.replace(/\/g$/, "").substring( 1 ), "g" ) :
-		new RegExp( regex.substring( 1, regex.length-1 ) );
+		new RegExp( regex.replace( /\/g$/, "" ).substring( 1 ), "g" ) :
+		new RegExp( regex.substring( 1, regex.length - 1 ) );
 }
 
 function parseToken( token ) { // jshint ignore:line
@@ -73,20 +73,18 @@ function parseToken( token ) { // jshint ignore:line
 	return {
 		original: token,
 		namespace: parts.length > 2 ? parts.slice( 0, parts.length - 2 ) : "",
-		resource: parts.length > 1 ? parts[ parts.length -2 ] : "",
-		property: parts[ parts.length -1 ]
+		resource: parts.length > 1 ? parts[ parts.length - 2 ] : "",
+		property: parts[ parts.length - 1 ]
 	};
 }
 
 function readDataByToken( resource, data, token ) {
 	var value;
 	var camel = camelCase( token );
-	if( data ) {
-		value = 
-			data[ camel ]
-			|| ( data[ token.resource ] ? data[ token.resource ][ token.property ] : undefined )
-			//|| data[ token.property ];
-			|| ( resource === token.resource ? data[ token.property ] : undefined );
+	if ( data ) {
+		value = data[ camel ]
+		|| ( data[ token.resource ] ? data[ token.resource ][ token.property ] : undefined )
+		|| ( resource === token.resource ? data[ token.property ] : undefined );
 	}
 	var empty = value === undefined || value === {};
 	var backup = !token.isChild && token.resource && token.resource === resource ? token.property : camel;
@@ -96,7 +94,7 @@ function readDataByToken( resource, data, token ) {
 
 function processTokens( tokens, url, data, resource ) { // jshint ignore:line
 	var token = tokens.pop();
-	if( token ) {
+	if ( token ) {
 		var replacement = readDataByToken( resource, data, token );
 		var stringified = ( braceReplace.toString() ).replace( /replace/, token.original );
 		var replacer = parseRegex( stringified );


### PR DESCRIPTION
Previous lib did not handle words like 'child' well so you got 'childs' (ew). Pluralize handles more of these edge cases and has a lot of additional capabilities that could be used down the road if needed.

> esformatter was loosed upon the src folder, hence the large change set for a relatively trivial change