### PR TITLE
separating out performance related specs

### DIFF
--- a/spec/behavior/condition.spec.js
+++ b/spec/behavior/condition.spec.js
@@ -1,8 +1,6 @@
 require( "../setup" );
 var HyperResource = require( "../../src/hyperResource.js" );
 
-var limit = 4;
-
 describe( "when filtering links by predicate", function() {
 	var resource = {
 		name: "account",
@@ -73,20 +71,12 @@ describe( "when filtering links by predicate", function() {
 	var newAccount, withMoney, noMoney, elapsed1, elapsed2, elapsed3, elapsed4;
 
 	before( function() {
-		var start = Date.now();
 		var fn = HyperResource.renderFn( { account: resource } );
-		elapsed1 = ( Date.now() - start );
-		start = Date.now();
 		newAccount = fn( "account", "self", acct );
-		elapsed2 = ( Date.now() - start );
 		acct.balance = 100;
-		start = Date.now();
 		withMoney = fn( "account", "self", acct );
-		elapsed3 = ( Date.now() - start );
 		acct.balance = 0;
-		start = Date.now();
 		noMoney = fn( "account", "self", acct );
-		elapsed4 = ( Date.now() - start );
 	} );
 
 	it( "should only show withdrawal if balance is greater than 0", function() {
@@ -95,10 +85,4 @@ describe( "when filtering links by predicate", function() {
 		noMoney.should.eql( expected3 );
 	} );
 
-	it( "should be 'quick'", function() {
-		elapsed1.should.be.below( limit );
-		elapsed2.should.be.below( limit );
-		elapsed3.should.be.below( limit );
-		elapsed4.should.be.below( limit );
-	} );
 } );

--- a/spec/behavior/hyperResource.spec.js
+++ b/spec/behavior/hyperResource.spec.js
@@ -2,8 +2,6 @@ require( "../setup" );
 var url = require( "../../src/urlTemplate.js" );
 var HyperResource = require( "../../src/hyperResource.js" );
 
-var limit = 15;
-
 var resources = require( "./resources.js" );
 
 describe( "Action links", function() {
@@ -403,23 +401,16 @@ describe( "Action links", function() {
 				title: "child",
 				grandChildren: [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 } ]
 			};
-			var elapsed;
 
 			before( function() {
 				var fn1 = HyperResource.resourceFn( resources, "/test/api" );
-
-				var start = Date.now();
 				response = fn1( "child", "self", data );
-				elapsed = Date.now() - start;
 			} );
 
 			it( "should return the correct response", function() {
 				response.should.eql( expected );
 			} );
 
-			it( "new should be 'quick'", function() {
-				elapsed.should.be.below( limit );
-			} );
 		} );
 	} );
 
@@ -527,23 +518,16 @@ describe( "Action links", function() {
 				children: [ {} ]
 			}
 		];
-		var elapsed;
 
 		before( function() {
 			var fn1 = HyperResource.resourcesFn( resources );
-
-			var start = Date.now();
 			response = fn1( "parent", "self", data, "", undefined, "/parent", "GET" );
-			elapsed = Date.now() - start;
 		} );
 
 		it( "should return the correct response", function() {
 			response.should.eql( expected );
 		} );
 
-		it( "new should be 'quick'", function() {
-			elapsed.should.be.below( limit );
-		} );
 	} );
 
 	describe( "when rendering a list of resources from another resource", function() {
@@ -591,47 +575,34 @@ describe( "Action links", function() {
 				description: "the second item"
 			}
 		];
-		var elapsed;
 
 		before( function() {
 			var fn1 = HyperResource.resourcesFn( resources );
-			var start = Date.now();
 			response = fn1( "child", "self", data, "", undefined, "/parent/1/child", "GET" );
-			elapsed = Date.now() - start;
 		} );
 
 		it( "should return the correct response", function() {
 			response.should.eql( expected );
 		} );
 
-		it( "new should be 'quick'", function() {
-			elapsed.should.be.below( limit );
-		} );
 	} );
 
 	describe( "Timing token replacement", function() {
 		var testUrl = "/parent/:id/child/:child.id";
 
 		describe( "Replacing 2 tokens 1000 times with regex", function() {
-			var elapsed;
 			var urls = [];
 			before( function() {
-				var start = Date.now();
 				var tokens = url.getTokens( testUrl );
 				var halUrl = url.forHal( testUrl );
 				for (var i = 0; i < 1000; i++) {
 
 					urls.push( url.process( _.clone( tokens ), halUrl, { id: 1, childId: 2 }, "parent" ) );
 				}
-				elapsed = Date.now() - start;
 			} );
 
 			it( "should produce a valid URL", function() {
 				urls[ 1 ].should.equal( "/parent/1/child/2" );
-			} );
-
-			it( "should be 'quick'", function() {
-				elapsed.should.be.below( 40 );
 			} );
 		} );
 	} );

--- a/spec/behavior/links.spec.js
+++ b/spec/behavior/links.spec.js
@@ -3,10 +3,8 @@ var model = require( "../model.js" );
 var HyperResource = require( "../../src/hyperResource.js" );
 
 var board1 = model.board1;
-var limit = 5;
 
 describe( "with static links", function() {
-	var elapsedMs;
 	var resource = {
 		name: "board",
 		actions: {
@@ -61,11 +59,9 @@ describe( "with static links", function() {
 	};
 
 	before( function() {
-		var start = Date.now();
 		var fn = HyperResource.renderFn( { board: resource } );
 		self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
 		self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
-		elapsedMs = Date.now() - start;
 	} );
 
 	it( "should generate links correctly", function() {
@@ -73,13 +69,9 @@ describe( "with static links", function() {
 		self2.should.eql( expectedSelf2 );
 	} );
 
-	it( "should be 'quick'", function() {
-		elapsedMs.should.be.below( limit );
-	} );
 } );
 
 describe( "with resource prefix", function() {
-	var elapsedMs;
 	var resource = {
 		name: "board",
 		urlPrefix: "/prefix",
@@ -135,11 +127,9 @@ describe( "with resource prefix", function() {
 	};
 
 	before( function() {
-		var start = Date.now();
 		var fn = HyperResource.renderFn( { board: resource } );
 		self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
 		self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
-		elapsedMs = Date.now() - start;
 	} );
 
 	it( "should generate links correctly", function() {
@@ -147,7 +137,4 @@ describe( "with resource prefix", function() {
 		self2.should.eql( expectedSelf2 );
 	} );
 
-	it( "should be 'quick'", function() {
-		elapsedMs.should.be.below( limit );
-	} );
 } );

--- a/spec/performance/conditionPerf.spec.js
+++ b/spec/performance/conditionPerf.spec.js
@@ -1,0 +1,51 @@
+require( "../setup" );
+var HyperResource = require( "../../src/hyperResource.js" );
+
+var limit = 4;
+
+require( "../setup" );
+var HyperResource = require( "../../src/hyperResource.js" );
+
+describe( "when filtering links by predicate with performance expectation", function() {
+	var resource = {
+		name: "account",
+		actions: {
+			self: {
+				method: "get",
+				url: "/account/:id",
+				include: [ "id", "balance" ]
+			}
+		}
+	};
+
+	var acct = {
+		id: 100100,
+		balance: 0
+	};
+
+	var newAccount, withMoney, noMoney, elapsed1, elapsed2, elapsed3, elapsed4;
+
+	before( function() {
+		var start = Date.now();
+		var fn = HyperResource.renderFn( { account: resource } );
+		elapsed1 = ( Date.now() - start );
+		start = Date.now();
+		newAccount = fn( "account", "self", acct );
+		elapsed2 = ( Date.now() - start );
+		acct.balance = 100;
+		start = Date.now();
+		withMoney = fn( "account", "self", acct );
+		elapsed3 = ( Date.now() - start );
+		acct.balance = 0;
+		start = Date.now();
+		noMoney = fn( "account", "self", acct );
+		elapsed4 = ( Date.now() - start );
+	} );
+
+	it( "should be 'quick'", function() {
+		elapsed1.should.be.below( limit );
+		elapsed2.should.be.below( limit );
+		elapsed3.should.be.below( limit );
+		elapsed4.should.be.below( limit );
+	} );
+} );

--- a/spec/performance/hyperResourcePerf.spec.js
+++ b/spec/performance/hyperResourcePerf.spec.js
@@ -1,0 +1,247 @@
+require( "../setup" );
+var url = require( "../../src/urlTemplate.js" );
+var HyperResource = require( "../../src/hyperResource.js" );
+
+var limit = 4;
+
+var resources = require( "../behavior/resources.js" );
+
+describe( "Action links performance", function() {
+
+	describe( "when rendering action with embedded resources with performance expectation", function() {
+		var expected = {
+			id: 2,
+			parentId: 1,
+			title: "child",
+			_origin: { href: "/test/api/parent/1/child/2", method: "GET" },
+			_resource: "child",
+			_action: "self",
+			_links: {
+				self: { href: "/test/api/parent/1/child/2", method: "GET" }
+			},
+			_embedded: {
+				grandChildren: [
+					{ id: 1,
+						_origin: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
+						_resource: "grandChild",
+						_action: "self",
+						_links: {
+							self: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
+							create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+						}
+					},
+					{ id: 2,
+						_origin: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
+						_resource: "grandChild",
+						_action: "self",
+						_links: {
+							self: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
+							create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+						}
+					},
+					{ id: 3,
+						_origin: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
+						_resource: "grandChild",
+						_action: "self",
+						_links: {
+							self: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
+							create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+						}
+					},
+					{ id: 4,
+						_origin: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
+						_resource: "grandChild",
+						_action: "self",
+						_links: {
+							self: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
+							create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+						}
+					},
+					{ id: 5,
+						_origin: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
+						_resource: "grandChild",
+						_action: "self",
+						_links: {
+							self: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
+							create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+						}
+					}
+				]
+			}
+		};
+		var response;
+		var data = {
+			id: 2,
+			parentId: 1,
+			title: "child",
+			grandChildren: [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 } ]
+		};
+		var elapsed;
+
+		before( function() {
+			var fn1 = HyperResource.resourceFn( resources, "/test/api" );
+			var start = Date.now();
+			response = fn1( "child", "self", data );
+			elapsed = Date.now() - start;
+		} );
+
+		it( "should be 'quick'", function() {
+			elapsed.should.be.below( limit );
+		} );
+	} );
+
+	describe( "when rendering a list of top-level resources with performance expectation", function() {
+		var parameters = {
+			size: { range: [ 1, 100 ] }
+		};
+		var expected = {
+			_origin: { href: "/parent", method: "GET" },
+			parents: [
+				{
+					id: 1,
+					title: "one",
+					children: [ {} ],
+					description: "the first item",
+					_origin: { href: "/parent/1", method: "GET" },
+					_resource: "parent",
+					_action: "self",
+					_links: {
+						self: { href: "/parent/1", method: "GET" },
+						list: { href: "/parent", method: "GET" },
+						children: { href: "/parent/1/child", method: "GET", parameters: parameters }
+					}
+				},
+				{
+					id: 2,
+					title: "two",
+					children: [ {} ],
+					description: "the second item",
+					_origin: { href: "/parent/2", method: "GET" },
+					_resource: "parent",
+					_action: "self",
+					_links: {
+						self: { href: "/parent/2", method: "GET" },
+						list: { href: "/parent", method: "GET" },
+						children: { href: "/parent/2/child", method: "GET", parameters: parameters }
+					}
+				}
+			]
+		};
+		var response;
+		var data = [
+			{
+				id: 1,
+				title: "one",
+				description: "the first item",
+				children: [ {} ]
+			},
+			{
+				id: 2,
+				title: "two",
+				description: "the second item",
+				children: [ {} ]
+			}
+		];
+		var elapsed;
+
+		before( function() {
+			var fn1 = HyperResource.resourcesFn( resources );
+
+			var start = Date.now();
+			response = fn1( "parent", "self", data, "", undefined, "/parent", "GET" );
+			elapsed = Date.now() - start;
+		} );
+
+		it( "should be 'quick'", function() {
+			elapsed.should.be.below( limit );
+		} );
+	} );
+
+	describe( "when rendering a list of resources from another resource with performance expectation", function() {
+		var expected = {
+			_origin: { href: "/parent/1/child", method: "GET" },
+			children: [
+				{
+					id: 1,
+					parentId: 1,
+					title: "one",
+					description: "the first item",
+					_resource: "child",
+					_action: "self",
+					_origin: { href: "/parent/1/child/1", method: "GET" },
+					_links: {
+						self: { href: "/parent/1/child/1", method: "GET" },
+					}
+				},
+				{
+					id: 2,
+					parentId: 1,
+					title: "two",
+					description: "the second item",
+					_resource: "child",
+					_action: "self",
+					_origin: { href: "/parent/1/child/2", method: "GET" },
+					_links: {
+						self: { href: "/parent/1/child/2", method: "GET" },
+					}
+				}
+			]
+		};
+
+		var response;
+		var data = [
+			{
+				id: 1,
+				parentId: 1,
+				title: "one",
+				description: "the first item"
+			},
+			{
+				id: 2,
+				parentId: 1,
+				title: "two",
+				description: "the second item"
+			}
+		];
+
+		var elapsed;
+
+		before( function() {
+			var fn1 = HyperResource.resourcesFn( resources );
+			var start = Date.now();
+			response = fn1( "child", "self", data, "", undefined, "/parent/1/child", "GET" );
+			elapsed = Date.now() - start;
+		} );
+
+		it( "should be 'quick'", function() {
+			elapsed.should.be.below( limit );
+		} );
+	} );
+
+	describe( "Timing token replacement with performance expectation", function() {
+		var testUrl = "/parent/:id/child/:child.id";
+
+		describe( "When replacing 2 tokens 1000 times with regex", function() {
+			var elapsed;
+			var urls = [];
+			before( function() {
+				var start = Date.now();
+				var tokens = url.getTokens( testUrl );
+				var halUrl = url.forHal( testUrl );
+				for (var i = 0; i < 1000; i++) {
+
+					urls.push( url.process( _.clone( tokens ), halUrl, { id: 1, childId: 2 }, "parent" ) );
+				}
+				elapsed = Date.now() - start;
+			} );
+
+			// it( "should produce a valid URL", function() {
+			// 	urls[ 1 ].should.equal( "/parent/1/child/2" );
+			// } );
+
+			it( "should be 'quick'", function() {
+				elapsed.should.be.below( 40 );
+			} );
+		} );
+	} );
+} );

--- a/spec/performance/linksPerf.spec.js
+++ b/spec/performance/linksPerf.spec.js
@@ -1,0 +1,87 @@
+require( "../setup" );
+var model = require( "../model.js" );
+var HyperResource = require( "../../src/hyperResource.js" );
+
+var board1 = model.board1;
+var limit = 5;
+
+describe( "with static links", function() {
+	var elapsedMs;
+	var resource = {
+		name: "board",
+		actions: {
+			self: {
+				method: "get",
+				url: "/board/:id",
+				include: [ "id", "title" ],
+				links: {
+					"favstarred": "/board/:id?favstarred=true",
+					"worstever": "/board/:id?h8=true",
+					"next-page": function( data, context ) {
+						return "/board/:id?page=" + ( context.page + 1 ) + "&size=" + context.size;
+					},
+					"prev-page": function( data, context ) {
+						if ( context.page && context.page > 1 ) {
+							return "/board/:id?page=" + ( context.page - 1 ) + "&size=" + context.size;
+						}
+					}
+				}
+			}
+		}
+	};
+
+	var self1, self2;
+
+	before( function() {
+		var start = Date.now();
+		var fn = HyperResource.renderFn( { board: resource } );
+		self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
+		self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
+		elapsedMs = Date.now() - start;
+	} );
+
+	it( "should be 'quick'", function() {
+		elapsedMs.should.be.below( limit );
+	} );
+} );
+
+describe( "with resource prefix", function() {
+	var elapsedMs;
+	var resource = {
+		name: "board",
+		urlPrefix: "/prefix",
+		actions: {
+			self: {
+				method: "get",
+				url: "/board/:id",
+				include: [ "id", "title" ],
+				links: {
+					"favstarred": "/board/:id?favstarred=true",
+					"worstever": "/board/:id?h8=true",
+					"next-page": function( data, context ) {
+						return "/board/:id?page=" + ( context.page + 1 ) + "&size=" + context.size;
+					},
+					"prev-page": function( data, context ) {
+						if ( context.page && context.page > 1 ) {
+							return "/board/:id?page=" + ( context.page - 1 ) + "&size=" + context.size;
+						}
+					}
+				}
+			}
+		}
+	};
+
+	var self1, self2;
+
+	before( function() {
+		var start = Date.now();
+		var fn = HyperResource.renderFn( { board: resource } );
+		self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
+		self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
+		elapsedMs = Date.now() - start;
+	} );
+
+	it( "should be 'quick'", function() {
+		elapsedMs.should.be.below( limit );
+	} );
+} );


### PR DESCRIPTION
when the performance specs failed (took longer to run than the `limit` specified) it could crash the mocha test run with a strange `task completion callback called too many times` error. this is an effort to pull the performance specific tests out so they don't have any effect on the rest of the test run. it also allows the performance specs to be nuked easily if that's what is eventually decided.

if we choose to keep the performance specs around, ill try to refactor the setup portion of the tests so the same code doesnt exist in both the performance and behavior specs 