### PR TITLE
Support undefined or empty prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.x
 
+### 0.2.2
+ * Improvement - support empty or undefined apiPrefix
+ * Bug fix - on apiPrefix of '/', '', or undefined, do not produce routes with empty segments
+
 ### 0.2.1
  * Bug fix - status code was not being set correctly using new object literal syntax.
  * Add support back for original render approach.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,18 +9,17 @@ gulp.task( 'coverage-watch', function() {
 
 gulp.task( 'show-coverage', bg.showCoverage() );
 
-gulp.task( 'continuous-specs', function() {
+gulp.task( 'continuous-test', function() {
 	return bg.test();
 } );
 
-gulp.task( 'specs-watch', function() {
-	bg.watch( [ 'continuous-specs' ] );
+gulp.task( 'test-watch', function() {
+	bg.watch( [ 'continuous-test' ] );
 } );
 
-gulp.task( 'test-and-exit', function() {
+gulp.task( 'test', function() {
 	return bg.testOnce();
 } );
 
 gulp.task( 'default', [ 'coverage', 'coverage-watch' ], function() {} );
-gulp.task( 'specs', [ 'continuous-specs', 'specs-watch' ], function() {} );
-gulp.task( 'build', [ 'test-and-exit' ] );
+gulp.task( 'ci', [ 'continuous-test', 'test-watch' ], function() {} );

--- a/spec/behavior/actionWithEmbeddedResources.js
+++ b/spec/behavior/actionWithEmbeddedResources.js
@@ -1,0 +1,60 @@
+module.exports = {
+	id: 2,
+	parentId: 1,
+	title: "child",
+	_origin: { href: "/test/api/parent/1/child/2", method: "GET" },
+	_resource: "child",
+	_action: "self",
+	_links: {
+		self: { href: "/test/api/parent/1/child/2", method: "GET" }
+	},
+	_embedded: {
+		grandChildren: [
+			{ id: 1,
+				_origin: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
+				_resource: "grandChild",
+				_action: "self",
+				_links: {
+					self: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
+					create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+				}
+			},
+			{ id: 2,
+				_origin: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
+				_resource: "grandChild",
+				_action: "self",
+				_links: {
+					self: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
+					create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+				}
+			},
+			{ id: 3,
+				_origin: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
+				_resource: "grandChild",
+				_action: "self",
+				_links: {
+					self: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
+					create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+				}
+			},
+			{ id: 4,
+				_origin: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
+				_resource: "grandChild",
+				_action: "self",
+				_links: {
+					self: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
+					create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+				}
+			},
+			{ id: 5,
+				_origin: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
+				_resource: "grandChild",
+				_action: "self",
+				_links: {
+					self: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
+					create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
+				}
+			}
+		]
+	}
+};

--- a/spec/behavior/hyperResource.spec.js
+++ b/spec/behavior/hyperResource.spec.js
@@ -336,66 +336,7 @@ describe( "Action links", function() {
 		} );
 
 		describe( "when rendering action with embedded resources", function() {
-			var expected = {
-				id: 2,
-				parentId: 1,
-				title: "child",
-				_origin: { href: "/test/api/parent/1/child/2", method: "GET" },
-				_resource: "child",
-				_action: "self",
-				_links: {
-					self: { href: "/test/api/parent/1/child/2", method: "GET" }
-				},
-				_embedded: {
-					grandChildren: [
-						{ id: 1,
-							_origin: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
-							_resource: "grandChild",
-							_action: "self",
-							_links: {
-								self: { href: "/test/api/parent/1/child/2/grand/1", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
-							}
-						},
-						{ id: 2,
-							_origin: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
-							_resource: "grandChild",
-							_action: "self",
-							_links: {
-								self: { href: "/test/api/parent/1/child/2/grand/2", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
-							}
-						},
-						{ id: 3,
-							_origin: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
-							_resource: "grandChild",
-							_action: "self",
-							_links: {
-								self: { href: "/test/api/parent/1/child/2/grand/3", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
-							}
-						},
-						{ id: 4,
-							_origin: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
-							_resource: "grandChild",
-							_action: "self",
-							_links: {
-								self: { href: "/test/api/parent/1/child/2/grand/4", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
-							}
-						},
-						{ id: 5,
-							_origin: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
-							_resource: "grandChild",
-							_action: "self",
-							_links: {
-								self: { href: "/test/api/parent/1/child/2/grand/5", method: "GET" },
-								create: { href: "/test/api/parent/1/child/2/grand", method: "POST" }
-							}
-						}
-					]
-				}
-			};
+			var expected = require( "./actionWithEmbeddedResources.js" );
 			var response;
 			var data = {
 				id: 2,
@@ -476,42 +417,7 @@ describe( "Action links", function() {
 	} );
 
 	describe( "when rendering a list of top-level resources", function() {
-		var parameters = {
-			size: { range: [ 1, 100 ] }
-		};
-		var expected = {
-			_origin: { href: "/parent", method: "GET" },
-			parents: [
-				{
-					id: 1,
-					title: "one",
-					children: [ {} ],
-					description: "the first item",
-					_origin: { href: "/parent/1", method: "GET" },
-					_resource: "parent",
-					_action: "self",
-					_links: {
-						self: { href: "/parent/1", method: "GET" },
-						list: { href: "/parent", method: "GET" },
-						children: { href: "/parent/1/child", method: "GET", parameters: parameters }
-					}
-				},
-				{
-					id: 2,
-					title: "two",
-					children: [ {} ],
-					description: "the second item",
-					_origin: { href: "/parent/2", method: "GET" },
-					_resource: "parent",
-					_action: "self",
-					_links: {
-						self: { href: "/parent/2", method: "GET" },
-						list: { href: "/parent", method: "GET" },
-						children: { href: "/parent/2/child", method: "GET", parameters: parameters }
-					}
-				}
-			]
-		};
+		var expected = require( "./topLevelResources.js" );
 		var response;
 		var data = [
 			{
@@ -547,35 +453,7 @@ describe( "Action links", function() {
 	} );
 
 	describe( "when rendering a list of resources from another resource", function() {
-		var expected = {
-			_origin: { href: "/parent/1/child", method: "GET" },
-			children: [
-				{
-					id: 1,
-					parentId: 1,
-					title: "one",
-					description: "the first item",
-					_resource: "child",
-					_action: "self",
-					_origin: { href: "/parent/1/child/1", method: "GET" },
-					_links: {
-						self: { href: "/parent/1/child/1", method: "GET" },
-					}
-				},
-				{
-					id: 2,
-					parentId: 1,
-					title: "two",
-					description: "the second item",
-					_resource: "child",
-					_action: "self",
-					_origin: { href: "/parent/1/child/2", method: "GET" },
-					_links: {
-						self: { href: "/parent/1/child/2", method: "GET" },
-					}
-				}
-			]
-		};
+		var expected = require( "./listFromOtherResource.js" );
 		var response;
 		var data = [
 			{

--- a/spec/behavior/listFromOtherResource.js
+++ b/spec/behavior/listFromOtherResource.js
@@ -1,0 +1,29 @@
+module.exports = {
+	_origin: { href: "/parent/1/child", method: "GET" },
+	children: [
+		{
+			id: 1,
+			parentId: 1,
+			title: "one",
+			description: "the first item",
+			_resource: "child",
+			_action: "self",
+			_origin: { href: "/parent/1/child/1", method: "GET" },
+			_links: {
+				self: { href: "/parent/1/child/1", method: "GET" },
+			}
+		},
+		{
+			id: 2,
+			parentId: 1,
+			title: "two",
+			description: "the second item",
+			_resource: "child",
+			_action: "self",
+			_origin: { href: "/parent/1/child/2", method: "GET" },
+			_links: {
+				self: { href: "/parent/1/child/2", method: "GET" },
+			}
+		}
+	]
+};

--- a/spec/behavior/topLevelResources.js
+++ b/spec/behavior/topLevelResources.js
@@ -1,0 +1,41 @@
+module.exports = {
+	_origin: { href: "/parent", method: "GET" },
+	parents: [
+		{
+			id: 1,
+			title: "one",
+			children: [ {} ],
+			description: "the first item",
+			_origin: { href: "/parent/1", method: "GET" },
+			_resource: "parent",
+			_action: "self",
+			_links: {
+				self: { href: "/parent/1", method: "GET" },
+				list: { href: "/parent", method: "GET" },
+				children: { href: "/parent/1/child", method: "GET",
+					parameters: {
+						size: { range: [ 1, 100 ] }
+					}
+				}
+			}
+		},
+		{
+			id: 2,
+			title: "two",
+			children: [ {} ],
+			description: "the second item",
+			_origin: { href: "/parent/2", method: "GET" },
+			_resource: "parent",
+			_action: "self",
+			_links: {
+				self: { href: "/parent/2", method: "GET" },
+				list: { href: "/parent", method: "GET" },
+				children: { href: "/parent/2/child", method: "GET",
+					parameters: {
+						size: { range: [ 1, 100 ] }
+					}
+				}
+			}
+		}
+	]
+};

--- a/spec/integration/autohost.spec.js
+++ b/spec/integration/autohost.spec.js
@@ -261,4 +261,124 @@ describe( "Autohost Integration", function() {
 		} );
 	} );
 
+	describe( "with undefined api prefix", function() {
+		var hyped, host;
+		before( function( done ) {
+			hyped = require( "../../src/index.js" )( true, true );
+			host = hyped.createHost( autohost, {
+				resources: "./spec/ah",
+				apiPrefix: undefined
+			}, function() {
+					host.start();
+					done();
+				} );
+		} );
+
+		describe( "when requesting board with no media type", function() {
+			var expected = require( "./board2.json" );
+			var body, contentType;
+
+			before( function( done ) {
+				request( "http://localhost:8800/board/100", function( err, res ) {
+					body = JSON.parse( res.body );
+					contentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
+					done();
+				} );
+			} );
+
+			it( "should get JSON version 2", function() {
+				contentType.should.equal( "application/json" );
+				body.should.eql( expected );
+			} );
+
+		} );
+
+		describe( "when hitting root with options verb", function() {
+			var body, contentType, elapsedMs;
+
+			var expectedOptions = require( "./halOptionsNoPrefix.json" );
+
+			before( function( done ) {
+				var start = Date.now();
+				elapsedMs = ( Date.now() - start );
+				request( { method: "OPTIONS", url: "http://localhost:8800" }, function( err, res ) {
+					body = res.body;
+					contentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
+					done();
+				} );
+			} );
+
+			it( "should get options", function() {
+				contentType.should.equal( "application/json" );
+				var json = JSON.parse( body );
+				delete json._links[ "ah:metrics" ];
+				json.should.eql( expectedOptions );
+			} );
+		} );
+
+		after( function() {
+			host.stop();
+		} );
+	} );
+
+	describe( "with empty api prefix", function() {
+		var hyped, host;
+		before( function( done ) {
+			hyped = require( "../../src/index.js" )( true, true );
+			host = hyped.createHost( autohost, {
+				resources: "./spec/ah",
+				apiPrefix: ""
+			}, function() {
+					host.start();
+					done();
+				} );
+		} );
+
+		describe( "when requesting board with no media type", function() {
+			var expected = require( "./board2.json" );
+			var body, contentType;
+
+			before( function( done ) {
+				request( "http://localhost:8800/board/100", function( err, res ) {
+					body = JSON.parse( res.body );
+					contentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
+					done();
+				} );
+			} );
+
+			it( "should get JSON version 2", function() {
+				contentType.should.equal( "application/json" );
+				body.should.eql( expected );
+			} );
+
+		} );
+
+		describe( "when hitting root with options verb", function() {
+			var body, contentType, elapsedMs;
+
+			var expectedOptions = require( "./halOptionsNoPrefix.json" );
+
+			before( function( done ) {
+				var start = Date.now();
+				elapsedMs = ( Date.now() - start );
+				request( { method: "OPTIONS", url: "http://localhost:8800" }, function( err, res ) {
+					body = res.body;
+					contentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
+					done();
+				} );
+			} );
+
+			it( "should get options", function() {
+				contentType.should.equal( "application/json" );
+				var json = JSON.parse( body );
+				delete json._links[ "ah:metrics" ];
+				json.should.eql( expectedOptions );
+			} );
+		} );
+
+		after( function() {
+			host.stop();
+		} );
+	} );
+
 } );

--- a/spec/integration/halOptionsNoPrefix.json
+++ b/spec/integration/halOptionsNoPrefix.json
@@ -1,0 +1,14 @@
+{
+	"_links":
+	{
+		"board:cards": { "href": "/board/{id}/card", "method": "GET", "templated": true },
+		"board:self": { "href": "/board/{id}", "method": "GET", "templated": true },
+		"card:self": { "href": "/card/{id}", "method": "GET", "templated": true },
+		"card:move": { "href": "/card/{id}/board/{boardId}/lane/{laneId}", "method": "PUT", "templated": true },
+		"card:block": { "href": "/card/{id}/block", "method": "PUT", "templated": true },
+		"lane:self": { "href": "/board/{boardId}/lane/{id}", "method": "GET", "templated": true },
+		"lane:cards": { "href": "/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true }
+	},
+	"_mediaTypes": [ "application/json", "application/hal+json" ],
+	"_versions": [ "1", "2" ]
+}

--- a/src/hyperResource.js
+++ b/src/hyperResource.js
@@ -101,7 +101,7 @@ function getActionUrlCache( resources, prefix, version ) {
 		rAcc[ resourceName ] = _.reduce( resource.actions, function( acc, action, actionName ) {
 			var actionSegment = resource.actions[ actionName ].url;
 			var resourceSegment = getResourcePrefix( actionSegment, resource, resourceName );
-			var actionUrl = [ resource.urlPrefix, resourceSegment, actionSegment ].join( "" );
+			var actionUrl = [ resource.urlPrefix, resourceSegment, actionSegment ].join( "" ).replace( "//", "/" );
 			var templated = isTemplated( actionUrl );
 			var getActionUrl = function() {
 				return actionUrl;
@@ -123,7 +123,7 @@ function getActionUrlCache( resources, prefix, version ) {
 				var href = [
 					getPrefix( parentUrl, data ),
 					getActionUrl( data )
-				].join( "" );
+				].join( "" ).replace( "//", "/" );
 				return href;
 			};
 
@@ -133,7 +133,7 @@ function getActionUrlCache( resources, prefix, version ) {
 					var href = [
 						getPrefix( parentUrl, data ),
 						linkFn( data, context )
-					].join( "" );
+					].join( "" ).replace( "//", "/" );
 					return href;
 				};
 			} );
@@ -249,7 +249,7 @@ function getLinkFn( link, resource, resourceName ) { // jshint ignore:line
 		return function( data, context ) {
 			var linkUrl = link( data, context );
 			if ( linkUrl ) {
-				linkUrl = [ resource.urlPrefix, linkUrl ].join( "" );
+				linkUrl = [ resource.urlPrefix, linkUrl ].join( "" ).replace( "//", "/" );
 				return isTemplated( linkUrl ) ?
 					url.create( linkUrl, data, resourceName ) :
 					linkUrl;
@@ -258,7 +258,7 @@ function getLinkFn( link, resource, resourceName ) { // jshint ignore:line
 			}
 		};
 	} else {
-		var halUrl = url.forHal( [ resource.urlPrefix, link ].join( "" ) );
+		var halUrl = url.forHal( [ resource.urlPrefix, link ].join( "" ).replace( "//", "/" ) );
 		var templated = isTemplated( halUrl );
 		if ( templated ) {
 			var tokens = url.getTokens( halUrl );
@@ -375,7 +375,7 @@ function getParentUrlCache( resources, version ) {
 		var meta = visitParent( k );
 		var segments = meta.segments;
 		var tokens = meta.tokens;
-		var joined = segments.join( "" );
+		var joined = segments.join( "" ).replace( "//", "/" );
 		acc[ k ] = {
 			url: joined,
 			tokens: tokens
@@ -393,7 +393,7 @@ function getParentUrlFn( resources, prefix, version ) { // jshint ignore:line
 		var tokens = _.clone( meta.tokens );
 		var parent = resources[ resourceName ].parent;
 		var resourceSegment = getResourcePrefix( meta.url, resources[ parent ], parent );
-		var parentUrl = [ prefix, resourceSegment, meta.url ].join( "" );
+		var parentUrl = [ prefix, resourceSegment, meta.url ].join( "" ).replace( "//", "/" );
 		var values = _.reduce( tokens, function( acc, token ) {
 			var val = url.readToken( resourceName, data, token );
 			acc[ token.property ] = acc[ token.camel ] = val;

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,12 @@ function addMiddleware( state, host, apiPrefix ) { // jshint ignore:line
 		host.use( state.apiPrefix, state.hyperMiddleware );
 	} else {
 		var urlPrefix = host.config.urlPrefix;
-		apiPrefix = host.config.apiPrefix || "/api";
-		state.prefix = [ urlPrefix, apiPrefix ].join( "" );
+		if( _.has( host.config, "apiPrefix" ) ) {
+			apiPrefix = host.config.apiPrefix === undefined ? "/" : host.config.apiPrefix;
+		} else {
+			apiPrefix = "/api";
+		}
+		state.prefix = [ urlPrefix, apiPrefix ].join( "" ).replace( "//", "/" );
 		host.http.middleware( state.prefix, state.optionsMiddleware, "options" );
 		host.http.middleware( state.prefix, state.hyperMiddleware, "hyped" );
 	}


### PR DESCRIPTION
 * Improvement - support empty or undefined apiPrefix
 * Bug fix - on apiPrefix of '/', '', or undefined, do not produce routes with empty segments