### PR TITLE
Now with actual context!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.2.x
 
+### Next
+ * Bug fix - defect in hyperResponse resulting in undefined context for conditional predicate on actions
+ * Add better top level describes to each spec module
+ * Add autohost integration test to ensure context is present in handle
+
 ### 0.2.4
 Bug fix - resources with custom urlPrefixes did not get hypermedia middleware
 

--- a/spec/ah/test/resource.js
+++ b/spec/ah/test/resource.js
@@ -1,0 +1,17 @@
+module.exports = function() {
+	return {
+		name: "test",
+		actions: {
+			self: {
+				method: "get",
+				url: "/",
+				handle: function( envelope ) {
+					return { data: envelope.context };
+				},
+				condition: function( data, context ) {
+					return context !== {};
+				}
+			}
+		}
+	};
+};

--- a/spec/behavior/auth.spec.js
+++ b/spec/behavior/auth.spec.js
@@ -4,48 +4,51 @@ var HyperResource = require( "../../src/hyperResource.js" );
 
 var board1 = model.board1;
 
-describe( "when filtering links by permission", function() {
-	var resource = {
-		name: "board",
-		actions: {
-			self: {
-				method: "get",
-				url: "/board/:id",
-				include: [ "id", "title" ]
-			},
-			full: {
-				method: "get",
-				url: "/board/:id?embed=lanes,cards,classOfService",
-				include: [ "id", "title", "description" ],
-				links: {
-					shouldGetOmitted: "/board/:id?WAT"
+describe( "Authorization", function() {
+	describe( "when filtering links by permission", function() {
+		var resource = {
+			name: "board",
+			actions: {
+				self: {
+					method: "get",
+					url: "/board/:id",
+					include: [ "id", "title" ]
+				},
+				full: {
+					method: "get",
+					url: "/board/:id?embed=lanes,cards,classOfService",
+					include: [ "id", "title", "description" ],
+					links: {
+						shouldGetOmitted: "/board/:id?WAT"
+					}
 				}
 			}
-		}
-	};
+		};
 
-	var self;
-	var expectedSelf = {
-		id: 100,
-		title: "Test Board",
-		_origin: { href: "/board/100", method: "GET" },
-		_links: {
-			self: { href: "/board/100", method: "GET" }
-		},
-		_resource: "board",
-		_action: "self"
-	};
+		var self;
+		var expectedSelf = {
+			id: 100,
+			title: "Test Board",
+			_origin: { href: "/board/100", method: "GET" },
+			_links: {
+				self: { href: "/board/100", method: "GET" }
+			},
+			_resource: "board",
+			_action: "self"
+		};
 
-	var authCheck = function( actionName ) {
-		return actionName !== "board:full";
-	};
+		var authCheck = function( actionName ) {
+			return actionName !== "board:full";
+		};
 
-	before( function() {
-		var fn = HyperResource.renderFn( { board: resource } );
-		self = fn( "board", "self", board1, "", undefined, undefined, undefined, authCheck );
-	} );
+		before( function() {
+			var fn = HyperResource.renderFn( { board: resource } );
+			self = fn( "board", "self", board1, "", undefined, undefined, undefined, authCheck );
+		} );
 
-	it( "should generate self hypermedia object model", function() {
-		self.should.eql( expectedSelf );
+		it( "should generate self hypermedia object model", function() {
+			self.should.eql( expectedSelf );
+		} );
 	} );
 } );
+

--- a/spec/behavior/condition.spec.js
+++ b/spec/behavior/condition.spec.js
@@ -3,102 +3,104 @@ var HyperResource = require( "../../src/hyperResource.js" );
 
 var limit = 4;
 
-describe( "when filtering links by predicate", function() {
-	var resource = {
-		name: "account",
-		actions: {
-			self: {
-				method: "get",
-				url: "/account/:id",
-				include: [ "id", "balance" ]
-			},
-			withdraw: {
-				method: "POST",
-				url: "/account/:id/withdrawal",
-				condition: function( account ) {
-					return account.balance > 0;
+describe( "Conditions", function() {
+	describe( "when filtering links by predicate", function() {
+		var resource = {
+			name: "account",
+			actions: {
+				self: {
+					method: "get",
+					url: "/account/:id",
+					include: [ "id", "balance" ]
 				},
-				include: [ "id", "accountId", "amount", "balance", "newBalance" ]
-			},
-			deposit: {
-				method: "POST",
-				url: "/account/:id/deposit",
-				include: [ "id", "accountId", "amount", "balance", "newBalance" ]
+				withdraw: {
+					method: "POST",
+					url: "/account/:id/withdrawal",
+					condition: function( account ) {
+						return account.balance > 0;
+					},
+					include: [ "id", "accountId", "amount", "balance", "newBalance" ]
+				},
+				deposit: {
+					method: "POST",
+					url: "/account/:id/deposit",
+					include: [ "id", "accountId", "amount", "balance", "newBalance" ]
+				}
 			}
-		}
-	};
+		};
 
-	var acct = {
-		id: 100100,
-		balance: 0
-	};
+		var acct = {
+			id: 100100,
+			balance: 0
+		};
 
-	var expected1 = {
-		id: 100100,
-		balance: 0,
-		_origin: { href: "/account/100100", method: "GET" },
-		_resource: "account",
-		_action: "self",
-		_links: {
-			self: { href: "/account/100100", method: "GET" },
-			deposit: { href: "/account/100100/deposit", method: "POST" }
-		}
-	};
+		var expected1 = {
+			id: 100100,
+			balance: 0,
+			_origin: { href: "/account/100100", method: "GET" },
+			_resource: "account",
+			_action: "self",
+			_links: {
+				self: { href: "/account/100100", method: "GET" },
+				deposit: { href: "/account/100100/deposit", method: "POST" }
+			}
+		};
 
-	var expected2 = {
-		id: 100100,
-		balance: 100,
-		_origin: { href: "/account/100100", method: "GET" },
-		_resource: "account",
-		_action: "self",
-		_links: {
-			self: { href: "/account/100100", method: "GET" },
-			withdraw: { href: "/account/100100/withdrawal", method: "POST" },
-			deposit: { href: "/account/100100/deposit", method: "POST" }
-		}
-	};
+		var expected2 = {
+			id: 100100,
+			balance: 100,
+			_origin: { href: "/account/100100", method: "GET" },
+			_resource: "account",
+			_action: "self",
+			_links: {
+				self: { href: "/account/100100", method: "GET" },
+				withdraw: { href: "/account/100100/withdrawal", method: "POST" },
+				deposit: { href: "/account/100100/deposit", method: "POST" }
+			}
+		};
 
-	var expected3 = {
-		id: 100100,
-		balance: 0,
-		_origin: { href: "/account/100100", method: "GET" },
-		_resource: "account",
-		_action: "self",
-		_links: {
-			self: { href: "/account/100100", method: "GET" },
-			deposit: { href: "/account/100100/deposit", method: "POST" }
-		}
-	};
+		var expected3 = {
+			id: 100100,
+			balance: 0,
+			_origin: { href: "/account/100100", method: "GET" },
+			_resource: "account",
+			_action: "self",
+			_links: {
+				self: { href: "/account/100100", method: "GET" },
+				deposit: { href: "/account/100100/deposit", method: "POST" }
+			}
+		};
 
-	var newAccount, withMoney, noMoney, elapsed1, elapsed2, elapsed3, elapsed4;
+		var newAccount, withMoney, noMoney, elapsed1, elapsed2, elapsed3, elapsed4;
 
-	before( function() {
-		var start = Date.now();
-		var fn = HyperResource.renderFn( { account: resource } );
-		elapsed1 = ( Date.now() - start );
-		start = Date.now();
-		newAccount = fn( "account", "self", acct );
-		elapsed2 = ( Date.now() - start );
-		acct.balance = 100;
-		start = Date.now();
-		withMoney = fn( "account", "self", acct );
-		elapsed3 = ( Date.now() - start );
-		acct.balance = 0;
-		start = Date.now();
-		noMoney = fn( "account", "self", acct );
-		elapsed4 = ( Date.now() - start );
-	} );
+		before( function() {
+			var start = Date.now();
+			var fn = HyperResource.renderFn( { account: resource } );
+			elapsed1 = ( Date.now() - start );
+			start = Date.now();
+			newAccount = fn( "account", "self", acct );
+			elapsed2 = ( Date.now() - start );
+			acct.balance = 100;
+			start = Date.now();
+			withMoney = fn( "account", "self", acct );
+			elapsed3 = ( Date.now() - start );
+			acct.balance = 0;
+			start = Date.now();
+			noMoney = fn( "account", "self", acct );
+			elapsed4 = ( Date.now() - start );
+		} );
 
-	it( "should only show withdrawal if balance is greater than 0", function() {
-		newAccount.should.eql( expected1 );
-		withMoney.should.eql( expected2 );
-		noMoney.should.eql( expected3 );
-	} );
+		it( "should only show withdrawal if balance is greater than 0", function() {
+			newAccount.should.eql( expected1 );
+			withMoney.should.eql( expected2 );
+			noMoney.should.eql( expected3 );
+		} );
 
-	it( "should be \"quick\"", function() {
-		elapsed1.should.be.below( limit );
-		elapsed2.should.be.below( limit );
-		elapsed3.should.be.below( limit );
-		elapsed4.should.be.below( limit );
+		it( "should be \"quick\"", function() {
+			elapsed1.should.be.below( limit );
+			elapsed2.should.be.below( limit );
+			elapsed3.should.be.below( limit );
+			elapsed4.should.be.below( limit );
+		} );
 	} );
 } );

--- a/spec/behavior/filter.spec.js
+++ b/spec/behavior/filter.spec.js
@@ -4,40 +4,42 @@ var hyperResource = require( "../../src/hyperResource.js" );
 
 var board1 = model.board1;
 
-describe( "with property filter", function() {
-	var resource = {
-		name: "board",
-		actions: {
-			self: {
-				method: "get",
-				url: "/board/:id",
-				filter: function( value, key ) {
-					return key.charAt( 0 ) !== "_" && key !== "lanes";
+describe( "Property Filtering", function() {
+	describe( "with property filter", function() {
+		var resource = {
+			name: "board",
+			actions: {
+				self: {
+					method: "get",
+					url: "/board/:id",
+					filter: function( value, key ) {
+						return key.charAt( 0 ) !== "_" && key !== "lanes";
+					}
 				}
 			}
-		}
-	};
+		};
 
-	var self;
-	var expectedSelf = {
-		id: 100,
-		title: "Test Board",
-		tags: [ "one", "two", "three" ],
-		description: "This is a board and stuff!",
-		_origin: { href: "/board/100", method: "GET" },
-		_resource: "board",
-		_action: "self",
-		_links: {
-			self: { href: "/board/100", method: "GET" }
-		}
-	};
+		var self;
+		var expectedSelf = {
+			id: 100,
+			title: "Test Board",
+			tags: [ "one", "two", "three" ],
+			description: "This is a board and stuff!",
+			_origin: { href: "/board/100", method: "GET" },
+			_resource: "board",
+			_action: "self",
+			_links: {
+				self: { href: "/board/100", method: "GET" }
+			}
+		};
 
-	before( function() {
-		var fn = hyperResource.renderFn( { board: resource } );
-		self = fn( "board", "self", board1 );
-	} );
+		before( function() {
+			var fn = hyperResource.renderFn( { board: resource } );
+			self = fn( "board", "self", board1 );
+		} );
 
-	it( "should generate hypermedia without `lanes` or `hidden` fields", function() {
-		self.should.eql( expectedSelf );
+		it( "should generate hypermedia without `lanes` or `hidden` fields", function() {
+			self.should.eql( expectedSelf );
+		} );
 	} );
 } );

--- a/spec/behavior/halEngine.spec.js
+++ b/spec/behavior/halEngine.spec.js
@@ -1,135 +1,137 @@
 require( "../setup" );
 var halEngine = require( "../../src/halEngine.js" );
 
-describe( "when rendering HAL", function() {
-	var hal;
+describe( "HAL Engine", function() {
+	describe( "when rendering HAL", function() {
+		var hal;
 
-	var hypermodel = {
-		id: 100,
-		title: "Test Board",
-		_origin: { href: "/board/100", method: "GET" },
-		_resource: "board",
-		_action: "self",
-		_links: {
-			self: { href: "/board/100", method: "GET" },
-			full: { href: "/board/100?embed=lanes,cards,classOfService", method: "GET" },
-			lanes: { href: "/board/100/lane", method: "GET" }
-		},
-		_embedded: {
-			lanes: [
-				{
-					id: 200, title: "To Do", wip: 0,
-					_origin: { href: "/board/100/lane/200", method: "GET" },
-					_resource: "lane",
-					_action: "self",
-					_links: {
-						self: { href: "/board/100/lane/200", method: "GET" },
-						cards: { href: "/board/100/lane/200/card", method: "GET" }
+		var hypermodel = {
+			id: 100,
+			title: "Test Board",
+			_origin: { href: "/board/100", method: "GET" },
+			_resource: "board",
+			_action: "self",
+			_links: {
+				self: { href: "/board/100", method: "GET" },
+				full: { href: "/board/100?embed=lanes,cards,classOfService", method: "GET" },
+				lanes: { href: "/board/100/lane", method: "GET" }
+			},
+			_embedded: {
+				lanes: [
+					{
+						id: 200, title: "To Do", wip: 0,
+						_origin: { href: "/board/100/lane/200", method: "GET" },
+						_resource: "lane",
+						_action: "self",
+						_links: {
+							self: { href: "/board/100/lane/200", method: "GET" },
+							cards: { href: "/board/100/lane/200/card", method: "GET" }
+						},
+						_embedded: {
+							cards: [
+								{ id: 301, title: "Card 1", description: "This is card 1",
+									_origin: { href: "/card/301", method: "GET" },
+									_resource: "card",
+									_action: "self",
+									_links: {
+										self: { href: "/card/301", method: "GET" },
+										move: { href: "/card/301/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
+										block: { href: "/card/301/block", method: "PUT" }
+									}
+								},
+								{ id: 302, title: "Card 2", description: "This is card 2",
+									_origin: { href: "/card/302", method: "GET" },
+									_resource: "card",
+									_action: "self",
+									_links: {
+										self: { href: "/card/302", method: "GET" },
+										move: { href: "/card/302/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
+										block: { href: "/card/302/block", method: "PUT" }
+									}
+								},
+								{ id: 303, title: "Card 3", description: "This is card 3",
+									_origin: { href: "/card/303", method: "GET" },
+									_resource: "card",
+									_action: "self",
+									_links: {
+										self: { href: "/card/303", method: "GET" },
+										move: { href: "/card/303/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
+										block: { href: "/card/303/block", method: "PUT" }
+									}
+								}
+							]
+						}
 					},
-					_embedded: {
-						cards: [
-							{ id: 301, title: "Card 1", description: "This is card 1",
-								_origin: { href: "/card/301", method: "GET" },
-								_resource: "card",
-								_action: "self",
-								_links: {
-									self: { href: "/card/301", method: "GET" },
-									move: { href: "/card/301/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
-									block: { href: "/card/301/block", method: "PUT" }
+					{
+						id: 201, title: "Doing", wip: 0,
+						_origin: { href: "/board/100/lane/201", method: "GET" },
+						_resource: "lane",
+						_action: "self",
+						_links: {
+							self: { href: "/board/100/lane/201", method: "GET" },
+							cards: { href: "/board/100/lane/201/card", method: "GET" }
+						},
+						_embedded: {
+							cards: [
+								{ id: 304, title: "Card 4", description: "This is card 4",
+									_origin: { href: "/card/304", method: "GET" },
+									_resource: "card",
+									_action: "self",
+									_links: {
+										self: { href: "/card/304", method: "GET" },
+										move: { href: "/card/304/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
+										block: { href: "/card/304/block", method: "PUT" }
+									}
 								}
-							},
-							{ id: 302, title: "Card 2", description: "This is card 2",
-								_origin: { href: "/card/302", method: "GET" },
-								_resource: "card",
-								_action: "self",
-								_links: {
-									self: { href: "/card/302", method: "GET" },
-									move: { href: "/card/302/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
-									block: { href: "/card/302/block", method: "PUT" }
-								}
-							},
-							{ id: 303, title: "Card 3", description: "This is card 3",
-								_origin: { href: "/card/303", method: "GET" },
-								_resource: "card",
-								_action: "self",
-								_links: {
-									self: { href: "/card/303", method: "GET" },
-									move: { href: "/card/303/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
-									block: { href: "/card/303/block", method: "PUT" }
-								}
-							}
-						]
-					}
-				},
-				{
-					id: 201, title: "Doing", wip: 0,
-					_origin: { href: "/board/100/lane/201", method: "GET" },
-					_resource: "lane",
-					_action: "self",
-					_links: {
-						self: { href: "/board/100/lane/201", method: "GET" },
-						cards: { href: "/board/100/lane/201/card", method: "GET" }
+							]
+						}
 					},
-					_embedded: {
-						cards: [
-							{ id: 304, title: "Card 4", description: "This is card 4",
-								_origin: { href: "/card/304", method: "GET" },
-								_resource: "card",
-								_action: "self",
-								_links: {
-									self: { href: "/card/304", method: "GET" },
-									move: { href: "/card/304/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
-									block: { href: "/card/304/block", method: "PUT" }
+					{
+						id: 202, title: "Done", wip: 0,
+						_origin: { href: "/board/100/lane/202", method: "GET" },
+						_resource: "lane",
+						_action: "self",
+						_links: {
+							self: { href: "/board/100/lane/202", method: "GET" },
+							cards: { href: "/board/100/lane/202/card", method: "GET" }
+						},
+						_embedded: {
+							cards: [
+								{ id: 305, title: "Card 5", description: "This is card 5",
+									_origin: { href: "/card/305", method: "GET" },
+									_resource: "card",
+									_action: "self",
+									_links: {
+										self: { href: "/card/305", method: "GET" },
+										move: { href: "/card/305/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
+										block: { href: "/card/305/block", method: "PUT" }
+									}
+								},
+								{ id: 306, title: "Card 6", description: "This is card 6",
+									_origin: { href: "/card/306", method: "GET" },
+									_resource: "card",
+									_action: "self",
+									_links: {
+										self: { href: "/card/306", method: "GET" },
+										move: { href: "/card/306/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
+										block: { href: "/card/306/block", method: "PUT" }
+									}
 								}
-							}
-						]
+							]
+						}
 					}
-				},
-				{
-					id: 202, title: "Done", wip: 0,
-					_origin: { href: "/board/100/lane/202", method: "GET" },
-					_resource: "lane",
-					_action: "self",
-					_links: {
-						self: { href: "/board/100/lane/202", method: "GET" },
-						cards: { href: "/board/100/lane/202/card", method: "GET" }
-					},
-					_embedded: {
-						cards: [
-							{ id: 305, title: "Card 5", description: "This is card 5",
-								_origin: { href: "/card/305", method: "GET" },
-								_resource: "card",
-								_action: "self",
-								_links: {
-									self: { href: "/card/305", method: "GET" },
-									move: { href: "/card/305/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
-									block: { href: "/card/305/block", method: "PUT" }
-								}
-							},
-							{ id: 306, title: "Card 6", description: "This is card 6",
-								_origin: { href: "/card/306", method: "GET" },
-								_resource: "card",
-								_action: "self",
-								_links: {
-									self: { href: "/card/306", method: "GET" },
-									move: { href: "/card/306/board/{boardId}/lane/{laneId}", method: "PUT", templated: true },
-									block: { href: "/card/306/block", method: "PUT" }
-								}
-							}
-						]
-					}
-				}
-			]
-		}
-	};
+				]
+			}
+		};
 
-	var expected = JSON.stringify( hypermodel );
+		var expected = JSON.stringify( hypermodel );
 
-	before( function() {
-		hal = halEngine( hypermodel );
-	} );
+		before( function() {
+			hal = halEngine( hypermodel );
+		} );
 
-	it( "should render hal JSON", function() {
-		hal.should.eql( expected );
+		it( "should render hal JSON", function() {
+			hal.should.eql( expected );
+		} );
 	} );
 } );

--- a/spec/behavior/hyperResponse.spec.js
+++ b/spec/behavior/hyperResponse.spec.js
@@ -1,0 +1,120 @@
+require( "../setup" );
+
+var HyperResponse = require( "../../src/hyperResponse" );
+
+// CAUTION - this particular class synthesizes a lot of various
+// inputs to create the hypermedia response. Trying to follow it may
+// or may not (but definitely will) give you a headache.
+describe( "Hyper Response", function() {
+	describe( "when creating response", function() {
+		var result, res, resMock;
+		before( function() {
+			// transport request fake
+			var req = {
+				_resource: "test",
+				_action: "self",
+				context: {
+					middlewareData: "secret"
+				},
+				extendHttp: {
+				}
+			};
+
+			// model - data property on hash returned from handler
+			var model = {
+				id: 1,
+				title: "ohhai",
+				description: "uh, just some thing"
+			};
+
+			// full hash returned from handler
+			var handleResult = {
+				status: 200,
+				data: model,
+				headers: {
+					custom: "yay, a goat!"
+				},
+				cookies: {
+					cookieMonster: "umnumnumnumnum"
+				}
+			};
+
+			// transport response mock
+			res = {
+				set: _.noop,
+				cookie: _.noop,
+				status: _.noop,
+				send: _.noop
+			};
+			resMock = sinon.mock( res );
+			resMock
+				.expects( "set" )
+				.withArgs( "Content-Type", "application/json" )
+				.once();
+
+			resMock
+				.expects( "set" )
+				.withArgs( "custom", "yay, a goat!" )
+				.once();
+
+			res.cookie( "cookieMonster", "umnumnumnumnum" );
+			resMock.expects( "status" )
+				.once()
+				.withArgs( 200 )
+				.returns( res );
+
+			resMock.expects( "send" )
+				.once()
+				.withArgs( model );
+
+			// engine just returns the data passed to it
+			var engine = function( x ) {
+				return x;
+			};
+			var contentType = "application/json";
+
+			// just mock the hyper resource
+			var hyperResource = sinon.mock();
+			hyperResource.withArgs(
+				"test",
+				"self",
+				model,
+				"",
+				{
+					middlewareData: "secret"
+				},
+				"/test",
+				"GET"
+			)
+			.twice() // twice because we call it, then render calls it
+			.returns( model );
+
+			var response = new HyperResponse( req, res, engine, hyperResource, contentType );
+			response.origin( "/test", "GET" );
+			result = req.extendHttp.render( {}, undefined, undefined, handleResult );
+			response.render();
+		} );
+
+		it( "should produce the exepcted result", function() {
+			result.should.eql( {
+				status: 200,
+				headers: {
+					"Content-Type": "application/json",
+					custom: "yay, a goat!"
+				},
+				cookies: {
+					cookieMonster: "umnumnumnumnum"
+				},
+				data: {
+					id: 1,
+					title: "ohhai",
+					description: "uh, just some thing"
+				}
+			} );
+		} );
+
+		it( "should render correctly", function() {
+			resMock.verify();
+		} );
+	} );
+} );

--- a/spec/behavior/jsonEngine.spec.js
+++ b/spec/behavior/jsonEngine.spec.js
@@ -2,7 +2,8 @@ require( "../setup" );
 var model = require( "../model.js" );
 var jsonEngine = require( "../../src/jsonEngine.js" );
 
-describe( "when rendering json", function() {
+describe( "JSON Engine", function() {
+	describe( "when rendering json", function() {
 	var json;
 
 	var hypermodel = {
@@ -113,4 +114,5 @@ describe( "when rendering json", function() {
 	it( "should render simple json", function() {
 		json.should.eql( expected );
 	} );
+} );
 } );

--- a/spec/behavior/links.spec.js
+++ b/spec/behavior/links.spec.js
@@ -5,153 +5,155 @@ var HyperResource = require( "../../src/hyperResource.js" );
 var board1 = model.board1;
 var limit = 5;
 
-describe( "with static links", function() {
-	var elapsedMs;
-	var resource = {
-		name: "board",
-		actions: {
-			self: {
-				method: "get",
-				url: "/board/:id",
-				include: [ "id", "title" ],
-				links: {
-					favstarred: "/board/:id?favstarred=true",
-					worstever: "/board/:id?h8=true",
-					"next-page": function( data, context ) {
-						return "/board/:id?page=" + ( context.page + 1 ) + "&size=" + context.size;
-					},
-					"prev-page": function( data, context ) {
-						if ( context.page && context.page > 1 ) {
-							return "/board/:id?page=" + ( context.page - 1 ) + "&size=" + context.size;
+describe( "Additional Links", function() {
+	describe( "with static links", function() {
+		var elapsedMs;
+		var resource = {
+			name: "board",
+			actions: {
+				self: {
+					method: "get",
+					url: "/board/:id",
+					include: [ "id", "title" ],
+					links: {
+						favstarred: "/board/:id?favstarred=true",
+						worstever: "/board/:id?h8=true",
+						"next-page": function( data, context ) {
+							return "/board/:id?page=" + ( context.page + 1 ) + "&size=" + context.size;
+						},
+						"prev-page": function( data, context ) {
+							if ( context.page && context.page > 1 ) {
+								return "/board/:id?page=" + ( context.page - 1 ) + "&size=" + context.size;
+							}
 						}
 					}
 				}
 			}
-		}
-	};
+		};
 
-	var self1, self2;
-	var expectedSelf1 = {
-		id: 100,
-		title: "Test Board",
-		_origin: { href: "/board/100", method: "GET" },
-		_resource: "board",
-		_action: "self",
-		_links: {
-			self: { href: "/board/100", method: "GET" },
-			favstarred: { href: "/board/100?favstarred=true", method: "GET" },
-			worstever: { href: "/board/100?h8=true", method: "GET" },
-			"next-page": { href: "/board/100?page=2&size=10", method: "GET" }
-		}
-	};
+		var self1, self2;
+		var expectedSelf1 = {
+			id: 100,
+			title: "Test Board",
+			_origin: { href: "/board/100", method: "GET" },
+			_resource: "board",
+			_action: "self",
+			_links: {
+				self: { href: "/board/100", method: "GET" },
+				favstarred: { href: "/board/100?favstarred=true", method: "GET" },
+				worstever: { href: "/board/100?h8=true", method: "GET" },
+				"next-page": { href: "/board/100?page=2&size=10", method: "GET" }
+			}
+		};
 
-	var expectedSelf2 = {
-		id: 100,
-		title: "Test Board",
-		_origin: { href: "/board/100", method: "GET" },
-		_resource: "board",
-		_action: "self",
-		_links: {
-			self: { href: "/board/100", method: "GET" },
-			favstarred: { href: "/board/100?favstarred=true", method: "GET" },
-			worstever: { href: "/board/100?h8=true", method: "GET" },
-			"next-page": { href: "/board/100?page=3&size=10", method: "GET" },
-			"prev-page": { href: "/board/100?page=1&size=10", method: "GET" }
-		}
-	};
+		var expectedSelf2 = {
+			id: 100,
+			title: "Test Board",
+			_origin: { href: "/board/100", method: "GET" },
+			_resource: "board",
+			_action: "self",
+			_links: {
+				self: { href: "/board/100", method: "GET" },
+				favstarred: { href: "/board/100?favstarred=true", method: "GET" },
+				worstever: { href: "/board/100?h8=true", method: "GET" },
+				"next-page": { href: "/board/100?page=3&size=10", method: "GET" },
+				"prev-page": { href: "/board/100?page=1&size=10", method: "GET" }
+			}
+		};
 
-	before( function() {
-		var start = Date.now();
-		var fn = HyperResource.renderFn( { board: resource } );
-		self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
-		self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
-		elapsedMs = Date.now() - start;
+		before( function() {
+			var start = Date.now();
+			var fn = HyperResource.renderFn( { board: resource } );
+			self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
+			self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
+			elapsedMs = Date.now() - start;
+		} );
+
+		it( "should generate links correctly", function() {
+			self1.should.eql( expectedSelf1 );
+			self2.should.eql( expectedSelf2 );
+		} );
+
+		it( "should be \"quick\"", function() {
+			elapsedMs.should.be.below( limit );
+		} );
 	} );
 
-	it( "should generate links correctly", function() {
-		self1.should.eql( expectedSelf1 );
-		self2.should.eql( expectedSelf2 );
-	} );
-
-	it( "should be \"quick\"", function() {
-		elapsedMs.should.be.below( limit );
-	} );
-} );
-
-describe( "with resource prefixes", function() {
-	var elapsedMs;
-	var resource = {
-		name: "board",
-		urlPrefix: "/prefix1",
-		apiPrefix: "/prefix2",
-		actions: {
-			self: {
-				method: "get",
-				url: "/board/:id",
-				include: [ "id", "title" ],
-				links: {
-					favstarred: "/board/:id?favstarred=true",
-					worstever: "/board/:id?h8=true",
-					"next-page": function( data, context ) {
-						return "/board/:id?page=" + ( context.page + 1 ) + "&size=" + context.size;
-					},
-					"prev-page": function( data, context ) {
-						if ( context.page && context.page > 1 ) {
-							return "/board/:id?page=" + ( context.page - 1 ) + "&size=" + context.size;
+	describe( "with resource prefixes", function() {
+		var elapsedMs;
+		var resource = {
+			name: "board",
+			urlPrefix: "/prefix1",
+			apiPrefix: "/prefix2",
+			actions: {
+				self: {
+					method: "get",
+					url: "/board/:id",
+					include: [ "id", "title" ],
+					links: {
+						favstarred: "/board/:id?favstarred=true",
+						worstever: "/board/:id?h8=true",
+						"next-page": function( data, context ) {
+							return "/board/:id?page=" + ( context.page + 1 ) + "&size=" + context.size;
+						},
+						"prev-page": function( data, context ) {
+							if ( context.page && context.page > 1 ) {
+								return "/board/:id?page=" + ( context.page - 1 ) + "&size=" + context.size;
+							}
 						}
 					}
 				}
 			}
-		}
-	};
+		};
 
-	var self1, self2;
-	var expectedSelf1 = {
-		id: 100,
-		title: "Test Board",
-		_origin: { href: "/prefix1/prefix2/board/100", method: "GET" },
-		_resource: "board",
-		_action: "self",
-		_links: {
-			self: { href: "/prefix1/prefix2/board/100", method: "GET" },
-			favstarred: { href: "/prefix1/prefix2/board/100?favstarred=true", method: "GET" },
-			worstever: { href: "/prefix1/prefix2/board/100?h8=true", method: "GET" },
-			"next-page": { href: "/prefix1/prefix2/board/100?page=2&size=10", method: "GET" }
-		}
-	};
+		var self1, self2;
+		var expectedSelf1 = {
+			id: 100,
+			title: "Test Board",
+			_origin: { href: "/prefix1/prefix2/board/100", method: "GET" },
+			_resource: "board",
+			_action: "self",
+			_links: {
+				self: { href: "/prefix1/prefix2/board/100", method: "GET" },
+				favstarred: { href: "/prefix1/prefix2/board/100?favstarred=true", method: "GET" },
+				worstever: { href: "/prefix1/prefix2/board/100?h8=true", method: "GET" },
+				"next-page": { href: "/prefix1/prefix2/board/100?page=2&size=10", method: "GET" }
+			}
+		};
 
-	var expectedSelf2 = {
-		id: 100,
-		title: "Test Board",
-		_origin: { href: "/prefix1/prefix2/board/100", method: "GET" },
-		_resource: "board",
-		_action: "self",
-		_links: {
-			self: { href: "/prefix1/prefix2/board/100", method: "GET" },
-			favstarred: { href: "/prefix1/prefix2/board/100?favstarred=true", method: "GET" },
-			worstever: { href: "/prefix1/prefix2/board/100?h8=true", method: "GET" },
-			"next-page": { href: "/prefix1/prefix2/board/100?page=3&size=10", method: "GET" },
-			"prev-page": { href: "/prefix1/prefix2/board/100?page=1&size=10", method: "GET" }
-		}
-	};
+		var expectedSelf2 = {
+			id: 100,
+			title: "Test Board",
+			_origin: { href: "/prefix1/prefix2/board/100", method: "GET" },
+			_resource: "board",
+			_action: "self",
+			_links: {
+				self: { href: "/prefix1/prefix2/board/100", method: "GET" },
+				favstarred: { href: "/prefix1/prefix2/board/100?favstarred=true", method: "GET" },
+				worstever: { href: "/prefix1/prefix2/board/100?h8=true", method: "GET" },
+				"next-page": { href: "/prefix1/prefix2/board/100?page=3&size=10", method: "GET" },
+				"prev-page": { href: "/prefix1/prefix2/board/100?page=1&size=10", method: "GET" }
+			}
+		};
 
-	before( function() {
-		var fn = HyperResource.renderFn( { board: resource }, { urlPrefix: "/badUrl", apiPrefix: "/badUrl" } );
-		var start = Date.now();
-		self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
-		self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
-		elapsedMs = Date.now() - start;
-	} );
+		before( function() {
+			var fn = HyperResource.renderFn( { board: resource }, { urlPrefix: "/badUrl", apiPrefix: "/badUrl" } );
+			var start = Date.now();
+			self1 = fn( "board", "self", board1, "", { page: 1, size: 10 } );
+			self2 = fn( "board", "self", board1, "", { page: 2, size: 10 } );
+			elapsedMs = Date.now() - start;
+		} );
 
-	it( "should generate links correctly for page 1", function() {
-		self1.should.eql( expectedSelf1 );
-	} );
+		it( "should generate links correctly for page 1", function() {
+			self1.should.eql( expectedSelf1 );
+		} );
 
-	it( "should generate links correctly for page 2", function() {
-		self2.should.eql( expectedSelf2 );
-	} );
+		it( "should generate links correctly for page 2", function() {
+			self2.should.eql( expectedSelf2 );
+		} );
 
-	it( "should be \"quick\"", function() {
-		elapsedMs.should.be.below( limit );
+		it( "should be \"quick\"", function() {
+			elapsedMs.should.be.below( limit );
+		} );
 	} );
 } );

--- a/spec/behavior/url.spec.js
+++ b/spec/behavior/url.spec.js
@@ -1,105 +1,107 @@
 require( "../setup" );
 var url = require( "../../src/urlTemplate.js" );
 
-describe( "when replacing a token property with a model property", function() {
-	var template = "/this/is/{a.test}/of.stuff";
-	var model = { test: "atest" };
-	var expected = "/this/is/atest/of.stuff";
-	var href;
+describe( "URL Template", function() {
+	describe( "when replacing a token property with a model property", function() {
+		var template = "/this/is/{a.test}/of.stuff";
+		var model = { test: "atest" };
+		var expected = "/this/is/atest/of.stuff";
+		var href;
 
-	before( function() {
-		href = url.create( template, model, "a" );
+		before( function() {
+			href = url.create( template, model, "a" );
+		} );
+
+		it( "should replace the token with the matching model property", function() {
+			href.should.equal( expected );
+		} );
 	} );
 
-	it( "should replace the token with the matching model property", function() {
-		href.should.equal( expected );
-	} );
-} );
+	describe( "when replacing multiple tokens with matches", function() {
+		var template = "/parent/:parent.id/child/:child.id/grand/:id";
+		var model = { parentId: 1, childId: 2, id: 3 };
+		var expected = "/parent/1/child/2/grand/3";
+		var href;
 
-describe( "when replacing multiple tokens with matches", function() {
-	var template = "/parent/:parent.id/child/:child.id/grand/:id";
-	var model = { parentId: 1, childId: 2, id: 3 };
-	var expected = "/parent/1/child/2/grand/3";
-	var href;
+		before( function() {
+			href = url.create( template, model, "grandChild" );
+		} );
 
-	before( function() {
-		href = url.create( template, model, "grandChild" );
-	} );
-
-	it( "should replace all tokens correctly", function() {
-		href.should.equal( expected );
-	} );
-} );
-
-describe( "when replacing a token with a model property", function() {
-	var template = "/this/is/{test}/of.stuff";
-	var model = { test: "atest" };
-	var expected = "/this/is/atest/of.stuff";
-	var href;
-
-	before( function() {
-		href = url.create( template, model, "a" );
+		it( "should replace all tokens correctly", function() {
+			href.should.equal( expected );
+		} );
 	} );
 
-	it( "should replace the token with the matching model property", function() {
-		href.should.equal( expected );
-	} );
-} );
+	describe( "when replacing a token with a model property", function() {
+		var template = "/this/is/{test}/of.stuff";
+		var model = { test: "atest" };
+		var expected = "/this/is/atest/of.stuff";
+		var href;
 
-describe( "when a token has no corresponding model property", function() {
-	var template = "/this/is/{derp}/of.stuff";
-	var model = { test: "atest" };
-	var expected = "/this/is/{derp}/of.stuff";
-	var href;
+		before( function() {
+			href = url.create( template, model, "a" );
+		} );
 
-	before( function() {
-		href = url.create( template, model, "a" );
-	} );
-
-	it( "should keep token in place", function() {
-		href.should.equal( expected );
-	} );
-} );
-
-describe( "when a token property has no corresponding model property", function() {
-	var template = "/this/is/{herp.derp}/of.stuff";
-	var model = { test: "atest" };
-	var expected = "/this/is/{herpDerp}/of.stuff";
-	var href;
-
-	before( function() {
-		href = url.create( template, model, "a" );
+		it( "should replace the token with the matching model property", function() {
+			href.should.equal( expected );
+		} );
 	} );
 
-	it( "should create a camel cased token name", function() {
-		href.should.equal( expected );
-	} );
-} );
+	describe( "when a token has no corresponding model property", function() {
+		var template = "/this/is/{derp}/of.stuff";
+		var model = { test: "atest" };
+		var expected = "/this/is/{derp}/of.stuff";
+		var href;
 
-describe( "when replacing path variables for use in express", function() {
-	var template = "/this/is/{herp.derp}/of.stuff/{id}";
-	var expected = "/this/is/:herp.derp/of.stuff/:id";
-	var href;
+		before( function() {
+			href = url.create( template, model, "a" );
+		} );
 
-	before( function() {
-		href = url.forExpress( template );
-	} );
-
-	it( "should replace token with express-friendly version", function() {
-		href.should.equal( expected );
-	} );
-} );
-
-describe( "when replacing path variables for use in hal", function() {
-	var template = "/resource/:id/child/:herp.derp";
-	var expected = "/resource/{id}/child/{herp.derp}";
-	var href;
-
-	before( function() {
-		href = url.forHal( template );
+		it( "should keep token in place", function() {
+			href.should.equal( expected );
+		} );
 	} );
 
-	it( "should replace token with hal-friendly version", function() {
-		href.should.equal( expected );
+	describe( "when a token property has no corresponding model property", function() {
+		var template = "/this/is/{herp.derp}/of.stuff";
+		var model = { test: "atest" };
+		var expected = "/this/is/{herpDerp}/of.stuff";
+		var href;
+
+		before( function() {
+			href = url.create( template, model, "a" );
+		} );
+
+		it( "should create a camel cased token name", function() {
+			href.should.equal( expected );
+		} );
+	} );
+
+	describe( "when replacing path variables for use in express", function() {
+		var template = "/this/is/{herp.derp}/of.stuff/{id}";
+		var expected = "/this/is/:herp.derp/of.stuff/:id";
+		var href;
+
+		before( function() {
+			href = url.forExpress( template );
+		} );
+
+		it( "should replace token with express-friendly version", function() {
+			href.should.equal( expected );
+		} );
+	} );
+
+	describe( "when replacing path variables for use in hal", function() {
+		var template = "/resource/:id/child/:herp.derp";
+		var expected = "/resource/{id}/child/{herp.derp}";
+		var href;
+
+		before( function() {
+			href = url.forHal( template );
+		} );
+
+		it( "should replace token with hal-friendly version", function() {
+			href.should.equal( expected );
+		} );
 	} );
 } );

--- a/spec/integration/autohost.spec.js
+++ b/spec/integration/autohost.spec.js
@@ -13,9 +13,34 @@ describe( "Autohost Integration", function() {
 				urlPrefix: "/test",
 				resources: "./spec/ah"
 			}, function() {
+					host.http.middleware( "/", function context( req, res, next ) {
+						req.context.test = {
+							message: "I came from middleware!"
+						};
+						next();
+					} );
 					host.start();
 					done();
 				} );
+		} );
+
+		describe( "when altering context", function() {
+			var body, contentType;
+
+			before( function( done ) {
+				request( "http://localhost:8800/test/api/test", { headers: { accept: "*/*" } }, function( err, res ) {
+					body = JSON.parse( res.body );
+					contentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
+					done();
+				} );
+			} );
+
+			it( "should get JSON representation of context", function() {
+				contentType.should.equal( "application/json" );
+				body.should.eql( {
+					test: { message: "I came from middleware!" }
+				} );
+			} );
 		} );
 
 		describe( "when requesting board with any media type", function() {

--- a/spec/integration/halOptions.json
+++ b/spec/integration/halOptions.json
@@ -7,7 +7,8 @@
 		"card:move": { "href": "/test/api/card/{id}/board/{boardId}/lane/{laneId}", "method": "PUT", "templated": true },
 		"card:block": { "href": "/test/api/card/{id}/block", "method": "PUT", "templated": true },
 		"lane:self": { "href": "/test/api/board/{boardId}/lane/{id}", "method": "GET", "templated": true },
-		"lane:cards": { "href": "/test/api/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true }
+		"lane:cards": { "href": "/test/api/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true },
+		"test:self": { "href": "/test/api/test/", "method": "GET" }
 	},
 	"_mediaTypes": [ "application/json", "application/hal+json" ],
 	"_versions": [ "1", "2" ]

--- a/spec/integration/halOptionsNoPrefix.json
+++ b/spec/integration/halOptionsNoPrefix.json
@@ -7,7 +7,8 @@
 		"card:move": { "href": "/card/{id}/board/{boardId}/lane/{laneId}", "method": "PUT", "templated": true },
 		"card:block": { "href": "/card/{id}/block", "method": "PUT", "templated": true },
 		"lane:self": { "href": "/board/{boardId}/lane/{id}", "method": "GET", "templated": true },
-		"lane:cards": { "href": "/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true }
+		"lane:cards": { "href": "/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true },
+		"test:self": { "href": "/test/", "method": "GET" }
 	},
 	"_mediaTypes": [ "application/json", "application/hal+json" ],
 	"_versions": [ "1", "2" ]

--- a/src/hyperResponse.js
+++ b/src/hyperResponse.js
@@ -16,7 +16,7 @@ var HyperResponse = function( req, res, engine, hyperResource, contentType ) {
 	this._req = req;
 	this._res = res;
 	this._contentType = contentType;
-	this._context = {};
+	this._context = req.context;
 	this._headers = {};
 	this._cookies = {};
 
@@ -25,7 +25,7 @@ var HyperResponse = function( req, res, engine, hyperResource, contentType ) {
 
 	req.extendHttp.render = req.render = function( host, resource, action, result ) {
 		var model = result.data ? result.data : result;
-		var context = result.context ? result.context : {};
+		var context = result.context ? result.context : self._context;
 		setModel( self, model, context );
 		self._code = result.status || result.statusCode || self._code;
 		self._headers = result.headers || {};
@@ -100,7 +100,6 @@ HyperResponse.prototype.getResponse = function() {
 HyperResponse.prototype.render = function() {
 	var res = this._res;
 	var response = this.getResponse();
-	res.set( "Content-Type", this._contentType );
 	if ( response.headers ) {
 		_.each( response.headers, function( v, k ) {
 			res.set( k, v );


### PR DESCRIPTION
Context was not being correctly handled by hyperResponse so that the condition predicate would never receive it, making it impossible to filter links based on context set by middleware.

__IMPORTANT: Be sure you add `&w=1` to the URL when reviewing!__
I added better wrapping describes so that it would be easier to tell what feature was being tested when reading test output.