### PR TITLE
Click merge to discover a new set of powerful list abilities recently discovered by local* developers in your area**!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
  * Don't evaluate authorize on hidden actions
  * Add method to envelope
  * Improvement - lists should include link hypermedia at the top level
+ * Improvement - lists should allow additional metadata in response
+ * Bug fix - don't call authorize multiple times per action link when generating a response
  * Bug fix - action links weren't rendered in hypermedia
  * Bug fix - action and resource were missing from lists
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,18 @@ The response literal has the following structure:
 	action: , // defaults to the action that received the request
 }
 ```
+### Controlling the top-level result
+The `resource` and `action` properties of the _response_ returned from your action handle control what resource and action metdata will be used when rendering the top-level response.
+
+### Rendering Lists
+If the `data` property contains an array, the rendering engine will assume that you are returning a list of the resource that owns the list action and use the `"self"` action to determine how to render each item.
+
+To change the resource or action that is used to render the items in the list, you can use the `render` property on the action and provide `resource` and/or `action` properties which will change what resource and action metadata are being used to render each item in the list.
+
+The property on the response containing the rendered items will be the pluralized form of the resource used to render each item. To control this yourself, you can provide a `_alias` property on data.
+
+### Rendering Lists With Metadata
+If the `data` property is an object with a `_list` property containing an array, then the array will be rendered as before but with the additional properties from data included as part of the body.
 
 ### With Autohost
 In an autohost handler, this literal will be processed by hyped first. The data property will be replaced by the output of the appropriate rendering engine. If only the data is returned from the handler, then that will be used to generate the data property of the literal with defaults used for all other properties.

--- a/spec/behavior/hyperResource.spec.js
+++ b/spec/behavior/hyperResource.spec.js
@@ -224,6 +224,38 @@ describe( "Hyper Resource", function() {
 		} );
 	} );
 
+	describe( "when rendering a list of top-level resources with metadata", function() {
+		var expected = require( "./listWithMetadata.js" );
+		var response;
+		var data = {
+			total: 2,
+			description: "no need to argue, parents just don't understand",
+			_list: [
+				{
+					id: 1,
+					title: "one",
+					description: "the first item",
+					children: [ {} ]
+				},
+				{
+					id: 2,
+					title: "two",
+					description: "the second item",
+					children: [ {} ]
+				}
+			]
+		};
+
+		before( function() {
+			var fn1 = HyperResource.resourcesGenerator( resources );
+			response = fn1( "parent", "self", { resource: "parent", action: "list" }, data, "", "/parent", "GET" );
+		} );
+
+		it( "should return the correct response", function() {
+			return response.should.eventually.eql( expected );
+		} );
+	} );
+
 	describe( "when rendering a list of resources from another resource", function() {
 		var expected = require( "./listFromOtherResource.js" );
 		var response;

--- a/spec/behavior/hyperResponse.spec.js
+++ b/spec/behavior/hyperResponse.spec.js
@@ -98,8 +98,8 @@ describe( "Hyper Response", function() {
 
 			var response = new HyperResponse( envelope, engine, hyperResource, contentType );
 			response.origin( "/test", "GET" );
-			result = req.extendHttp.render( {}, undefined, undefined, handleResult );
-			response.render();
+			req.extendHttp.render( {}, undefined, undefined, handleResult );
+			result = response.render();
 		} );
 
 		it( "should produce the exepcted result", function() {

--- a/spec/behavior/listWithMetadata.js
+++ b/spec/behavior/listWithMetadata.js
@@ -1,0 +1,48 @@
+module.exports = {
+	_origin: { href: "/parent", method: "GET" },
+	_resource: "parent",
+	_action: "list",
+	total: 2,
+	description: "no need to argue, parents just don't understand",
+	parents: [
+		{
+			id: 1,
+			title: "one",
+			children: [ {} ],
+			description: "the first item",
+			_origin: { href: "/parent/1", method: "GET" },
+			_resource: "parent",
+			_action: "self",
+			_links: {
+				self: { href: "/parent/1", method: "GET" },
+				children: { href: "/parent/1/child", method: "GET",
+					parameters: {
+						size: { range: [ 1, 100 ] }
+					}
+				}
+			}
+		},
+		{
+			id: 2,
+			title: "two",
+			children: [ {} ],
+			description: "the second item",
+			_origin: { href: "/parent/2", method: "GET" },
+			_resource: "parent",
+			_action: "self",
+			_links: {
+				self: { href: "/parent/2", method: "GET" },
+				children: { href: "/parent/2/child", method: "GET",
+					parameters: {
+						size: { range: [ 1, 100 ] }
+					}
+				}
+			}
+		}
+	],
+	_links: {
+		list: {
+			href: "/parent", method: "GET"
+		}
+	}
+};

--- a/src/hyperResponse.js
+++ b/src/hyperResponse.js
@@ -34,7 +34,6 @@ var HyperResponse = function( envelope, engine, hyperResource, contentType ) {
 		self._cookies = result.cookies || {};
 		self._resource = result.resource || self._resource;
 		self._action = result.action || self._action;
-		return self.getResponse();
 	};
 };
 
@@ -102,7 +101,7 @@ HyperResponse.prototype.getResponse = function() {
 
 HyperResponse.prototype.render = function() {
 	var res = this._res;
-	this.getResponse()
+	return this.getResponse()
 		.then( function( response ) {
 			if ( response.headers ) {
 				_.each( response.headers, function( v, k ) {
@@ -115,6 +114,7 @@ HyperResponse.prototype.render = function() {
 				} );
 			}
 			res.status( response.status ).send( response.data );
+			return response;
 		} );
 };
 


### PR DESCRIPTION
Adds the ability to control the list property used in the response via `_alias` and allows you to attach additional metadata to the rendered response by putting the items array on the `_list` property.

Also fixes a bug found by @dcneiner where authorize was getting called multiple times per action link when rendering the response. He didn't buy my, "Hey, we just wanna make super-extra sure and check every 5ms during the render!"

\* for some values of "local" constrained by country code
\** where "area" is defined by a circle with a radius of 2,000 miles or less
