### PR TITLE
Stop in-memory caching of OPTIONS calls

### DIFF
--- a/spec/ah/test/resource.js
+++ b/spec/ah/test/resource.js
@@ -20,6 +20,17 @@ module.exports = function() {
 				handle: function() {
 					return when.reject( new Error( "Something went wrong" ) );
 				}
+			},
+			sometimesShow: {
+				method: "get",
+				url: "/more",
+				actions: [],
+				authorize: function( envelope ) {
+					return envelope._original.req.headers.hasOwnProperty( "x-show-me-more" );
+				},
+				handle: function( envelope ) {
+					return { data: envelope.context };
+				}
 			}
 		}
 	};

--- a/spec/integration/autohost.spec.js
+++ b/spec/integration/autohost.spec.js
@@ -266,6 +266,43 @@ describe( "Autohost Integration", function() {
 			} );
 		} );
 
+		describe( "when hitting root with options verb and the options change between requests", function() {
+			var body, contentType, secondBody, secondContentType;
+			var expectedOptions = require( "./halOptions.json" );
+			var moreExpectedOptions = require( "./halOptionsMore.json" );
+
+			before( function( done ) {
+				request( { method: "OPTIONS", url: "http://localhost:8800/test/api" }, function( err, res ) {
+					body = res.body;
+					contentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
+
+					request( {
+						method: "OPTIONS",
+						url: "http://localhost:8800/test/api",
+						headers: { "x-show-me-more": "true" }
+					}, function( err, res ) {
+						secondBody = res.body;
+						secondContentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
+						done();
+					} );
+				} );
+			} );
+
+			it( "should get options", function() {
+				contentType.should.equal( "application/json" );
+				var json = JSON.parse( body );
+				delete json._links[ "ah:metrics" ];
+				json.should.eql( expectedOptions );
+			} );
+
+			it( "should get the additional link on the second call", function() {
+				secondContentType.should.equal( "application/json" );
+				var json = JSON.parse( secondBody );
+				delete json._links[ "ah:metrics" ];
+				json.should.eql( moreExpectedOptions );
+			} );
+		} );
+
 		after( function() {
 			host.stop();
 		} );

--- a/spec/integration/halOptionsMore.json
+++ b/spec/integration/halOptionsMore.json
@@ -1,0 +1,16 @@
+{
+	"_links":
+	{
+		"board:cards": { "href": "/test/api/board/{id}/card", "method": "GET", "templated": true },
+		"board:self": { "href": "/test/api/board/{id}", "method": "GET", "templated": true },
+		"card:self": { "href": "/test/api/card/{id}", "method": "GET", "templated": true },
+		"card:move": { "href": "/test/api/card/{id}/board/{targetBoardId}/lane/{targetLaneId}", "method": "PUT", "templated": true },
+		"card:block": { "href": "/test/api/card/{id}/block", "method": "PUT", "templated": true },
+		"lane:self": { "href": "/test/api/board/{boardId}/lane/{id}", "method": "GET", "templated": true },
+		"lane:cards": { "href": "/test/api/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true },
+		"test:self": { "href": "/test/api/test/", "method": "GET" },
+		"test:sometimesShow": { "href": "/test/api/test/more", "method": "GET" }
+	},
+	"_mediaTypes": [ "application/json", "application/hal+json" ],
+	"_versions": [ "1", "2" ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -117,10 +117,7 @@ function getOptionModel( state, envelope ) {
 	if ( envelope ) {
 		version = getVersion( state, envelope );
 	}
-	if ( !state.optionModels[ version ] ) {
-		state.optionModels[ version ] = HyperResource.optionsGenerator( state.resources, state.prefix, version, state.excludeChildren, envelope )( state.engines );
-	}
-	return state.optionModels[ version ];
+	return HyperResource.optionsGenerator( state.resources, state.prefix, version, state.excludeChildren, envelope )( state.engines );
 }
 
 function getFullOptionModel( state ) {
@@ -207,7 +204,6 @@ module.exports = function( resourceList, defaultToNewest, includeChildrenInOptio
 		engines: {},
 		hypermodels: {},
 		resources: {},
-		optionModels: {},
 		fullOptionModels: {},
 		prefix: undefined,
 		maxVersion: undefined,


### PR DESCRIPTION
In order to fully support the `authorize` calls, and any other conditional showing of links, we cannot cache the results of the `getOptionsModel` call.