### PR TITLE
Prefixes in your service are ready to try this one simple trick for working behind reverse proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.x
+
+### 0.5.0
+ * Bug fix - jsonEngine was turning strings in arrays into objects
+ * Refactor url generation to include resource url and api prefixes (instead of replacing them)
+
 ## 0.4.x
 
 ### 0.4.4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The resource definition provides the metadata necessary for hyped to generate hy
 {
 	[resourceName]: the resource name (must be unique)
 	parent: (optional) the name of the resource that this "belongs" to
-	urlPrefix: (optional) a URL prefix for all actions in this resource
+	urlPrefix: (optional) a resource-level URL prefix for all actions in this resource
+	apiPrefix: (optional) an api-level URL prefix for all actions in this resource
 	resourcePrefix: (optional) defaults to true - guarantees URLs begin with resource name
 	actions: {
 		[actionName]: {
@@ -85,7 +86,9 @@ The resource definition provides the metadata necessary for hyped to generate hy
 	<dt>parent</dt>
 	<dd>Defines this resource as belonging to another resource. This will cause all of the action URLs in this resource to be prefixed by the parent resource's <tt>self</tt> href.</dd>
 	<dt>urlPrefix</dt>
-	<dd>Provide a common URL prefix for all actions in this resource.</dd>
+	<dd>Provide a common URL prefix for all actions in this resource. This appears _after_ the server level urlPrefix and before either the server or resource apiPrefixes.</dd>
+	<dt>apiPrefix</dt>
+	<dd>Provide a common API prefix for all actions in this resource. This appears at the end of all prefixes right before the urlPath.</dd>
 	<dt>actionName</dt>
 	<dd>The name of the action will determine the name of the link exposed in the resource's links.</dd>
 	<dt>method</dt>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyped",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Hypermedia response generation engine",
   "main": "src/index.js",
   "dependencies": {

--- a/spec/ah/test/resource.js
+++ b/spec/ah/test/resource.js
@@ -1,6 +1,7 @@
 module.exports = function() {
 	return {
 		name: "test",
+		urlPrefix: "/prefix",
 		actions: {
 			self: {
 				method: "get",

--- a/spec/behavior/actions.spec.js
+++ b/spec/behavior/actions.spec.js
@@ -13,7 +13,7 @@ describe( "Action links", function() {
 					childId: 2,
 					id: 3
 				};
-				var fn = links.getParentUrlGenerator( resources, { urlPrefix: "/test", apiPrefix: "/api" } );
+				var fn = links.getParentUrlGenerator( {}, resources, { urlPrefix: "/test", apiPrefix: "/api" } );
 				urlCache = links.getParentUrlCache( resources, { urlPrefix: "/test", apiPrefix: "/api" } );
 				parent = fn( "parent", model );
 				child = fn( "child", model );

--- a/spec/behavior/links.spec.js
+++ b/spec/behavior/links.spec.js
@@ -120,29 +120,29 @@ describe( "Additional Links", function() {
 		var expectedSelf1 = {
 			id: 100,
 			title: "Test Board",
-			_origin: { href: "/prefix1/prefix2/board/100", method: "GET" },
+			_origin: { href: "/badUrl/prefix1/badUrl/prefix2/board/100", method: "GET" },
 			_resource: "board",
 			_action: "self",
 			_links: {
-				self: { href: "/prefix1/prefix2/board/100", method: "GET" },
-				favstarred: { href: "/prefix1/prefix2/board/100?favstarred=true", method: "GET" },
-				worstever: { href: "/prefix1/prefix2/board/100?h8=true", method: "GET" },
-				"next-page": { href: "/prefix1/prefix2/board/100?page=2&size=10", method: "GET" }
+				self: { href: "/badUrl/prefix1/badUrl/prefix2/board/100", method: "GET" },
+				favstarred: { href: "/badUrl/prefix1/badUrl/prefix2/board/100?favstarred=true", method: "GET" },
+				worstever: { href: "/badUrl/prefix1/badUrl/prefix2/board/100?h8=true", method: "GET" },
+				"next-page": { href: "/badUrl/prefix1/badUrl/prefix2/board/100?page=2&size=10", method: "GET" }
 			}
 		};
 
 		var expectedSelf2 = {
 			id: 100,
 			title: "Test Board",
-			_origin: { href: "/prefix1/prefix2/board/100", method: "GET" },
+			_origin: { href: "/badUrl/prefix1/badUrl/prefix2/board/100", method: "GET" },
 			_resource: "board",
 			_action: "self",
 			_links: {
-				self: { href: "/prefix1/prefix2/board/100", method: "GET" },
-				favstarred: { href: "/prefix1/prefix2/board/100?favstarred=true", method: "GET" },
-				worstever: { href: "/prefix1/prefix2/board/100?h8=true", method: "GET" },
-				"next-page": { href: "/prefix1/prefix2/board/100?page=3&size=10", method: "GET" },
-				"prev-page": { href: "/prefix1/prefix2/board/100?page=1&size=10", method: "GET" }
+				self: { href: "/badUrl/prefix1/badUrl/prefix2/board/100", method: "GET" },
+				favstarred: { href: "/badUrl/prefix1/badUrl/prefix2/board/100?favstarred=true", method: "GET" },
+				worstever: { href: "/badUrl/prefix1/badUrl/prefix2/board/100?h8=true", method: "GET" },
+				"next-page": { href: "/badUrl/prefix1/badUrl/prefix2/board/100?page=3&size=10", method: "GET" },
+				"prev-page": { href: "/badUrl/prefix1/badUrl/prefix2/board/100?page=1&size=10", method: "GET" }
 			}
 		};
 

--- a/spec/integration/autohost.spec.js
+++ b/spec/integration/autohost.spec.js
@@ -216,6 +216,7 @@ describe( "Autohost Integration", function() {
 
 		describe( "when rendering an endpoint with an rejected promise", function() {
 			var body, contentType, elapsedMs, httpStatus;
+			var expected = require( "./halCards.json" );
 
 			before( function( done ) {
 				var start = Date.now();

--- a/spec/integration/autohost.spec.js
+++ b/spec/integration/autohost.spec.js
@@ -28,7 +28,7 @@ describe( "Autohost Integration", function() {
 			var body, contentType;
 
 			before( function( done ) {
-				request( "http://localhost:8800/test/api/test", { headers: { accept: "*/*" } }, function( err, res ) {
+				request( "http://localhost:8800/test/prefix/api/test", { headers: { accept: "*/*" } }, function( err, res ) {
 					body = JSON.parse( res.body );
 					contentType = res.headers[ "content-type" ].split( ";" )[ 0 ];
 					done();
@@ -220,7 +220,7 @@ describe( "Autohost Integration", function() {
 
 			before( function( done ) {
 				var start = Date.now();
-				request.get( "http://localhost:8800/test/api/test/reject", { headers: { accept: "application/hal+json" } }, function( err, res ) {
+				request.get( "http://localhost:8800/test/prefix/api/test/reject", { headers: { accept: "application/hal+json" } }, function( err, res ) {
 					elapsedMs = ( Date.now() - start );
 					body = res.body;
 					httpStatus = res.statusCode;
@@ -236,7 +236,7 @@ describe( "Autohost Integration", function() {
 				json.should.eql( {
 					_action: "reject",
 					_origin: {
-						href: "/test/api/test/reject",
+						href: "/test/prefix/api/test/reject",
 						method: "GET"
 					},
 					_resource: "test",

--- a/spec/integration/halOptions.json
+++ b/spec/integration/halOptions.json
@@ -8,7 +8,7 @@
 		"card:block": { "href": "/test/api/card/{id}/block", "method": "PUT", "templated": true },
 		"lane:self": { "href": "/test/api/board/{boardId}/lane/{id}", "method": "GET", "templated": true },
 		"lane:cards": { "href": "/test/api/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true },
-		"test:self": { "href": "/test/api/test/", "method": "GET" }
+		"test:self": { "href": "/test/prefix/api/test/", "method": "GET" }
 	},
 	"_mediaTypes": [ "application/json", "application/hal+json" ],
 	"_versions": [ "1", "2" ]

--- a/spec/integration/halOptionsMore.json
+++ b/spec/integration/halOptionsMore.json
@@ -8,8 +8,8 @@
 		"card:block": { "href": "/test/api/card/{id}/block", "method": "PUT", "templated": true },
 		"lane:self": { "href": "/test/api/board/{boardId}/lane/{id}", "method": "GET", "templated": true },
 		"lane:cards": { "href": "/test/api/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true },
-		"test:self": { "href": "/test/api/test/", "method": "GET" },
-		"test:sometimesShow": { "href": "/test/api/test/more", "method": "GET" }
+		"test:self": { "href": "/test/prefix/api/test/", "method": "GET" },
+		"test:sometimesShow": { "href": "/test/prefix/api/test/more", "method": "GET" }
 	},
 	"_mediaTypes": [ "application/json", "application/hal+json" ],
 	"_versions": [ "1", "2" ]

--- a/spec/integration/halOptionsNoPrefix.json
+++ b/spec/integration/halOptionsNoPrefix.json
@@ -8,7 +8,7 @@
 		"card:block": { "href": "/card/{id}/block", "method": "PUT", "templated": true },
 		"lane:self": { "href": "/board/{boardId}/lane/{id}", "method": "GET", "templated": true },
 		"lane:cards": { "href": "/board/{boardId}/lane/{id}/card", "method": "GET", "templated": true },
-		"test:self": { "href": "/test/", "method": "GET" }
+		"test:self": { "href": "/prefix/test/", "method": "GET" }
 	},
 	"_mediaTypes": [ "application/json", "application/hal+json" ],
 	"_versions": [ "1", "2" ]

--- a/src/hyperResource.js
+++ b/src/hyperResource.js
@@ -154,6 +154,7 @@ function getResourceCache( resources, prefix, version ) {
 		var prefixes = getPrefix( resource );
 		var urlPrefix = [
 				prefixes.urlPrefix,
+				resource.urlPrefix,
 				prefixes.apiPrefix
 			].join( "" ).replace( "//", "/" );
 		rAcc[ resourceName ] = _.reduce( resource.actions, function( acc, action, actionName ) {

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ function addMiddleware( state, host, apiPrefix ) { // jshint ignore:line
 			urlPrefix: urlPrefix,
 			apiPrefix: apiPrefix
 		};
+
 		var prefixUrl = [
 			urlPrefix,
 			apiPrefix
@@ -46,6 +47,7 @@ function addResourceMiddleware( state, host ) {
 	var resourcePrefixes = _.filter( _.unique( _.pluck( _.values( state.resources ), "urlPrefix" ) ) );
 	_.each( resourcePrefixes, function( resourcePrefix ) {
 		var resourcePrefixUrl = [
+			state.prefix.urlPrefix,
 			resourcePrefix,
 			state.prefix.apiPrefix
 		].join( "" ).replace( "//", "/" );


### PR DESCRIPTION
 * Bug fix - jsonEngine was turning strings in arrays into objects
 * Refactor url generation to include resource url and api prefixes (instead of replacing them)