### PR TITLE
When not using HAL, still render empty arrays at the top-level for embedded resources

### DIFF
--- a/spec/behavior/hyperResource.spec.js
+++ b/spec/behavior/hyperResource.spec.js
@@ -109,6 +109,68 @@ describe( "Hyper Resource", function() {
 				return response.should.eventually.eql( expected );
 			} );
 		} );
+
+		describe( "when rendering action with embedded resources and not using hal", function() {
+			var response;
+			var data = {
+				id: 2,
+				parentId: 1,
+				title: "child",
+				grandChildren: [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 } ]
+			};
+			var envelope = {
+				user: {
+					name: "Evenly"
+				}
+			};
+			before( function() {
+				var fn1 = HyperResource.resourceGenerator( resources, { urlPrefix: "/test", apiPrefix: "/api" } );
+				response = fn1( "child", "self", envelope, data, "", undefined, undefined, false );
+			} );
+
+			it( "should keep embedded resources as top-level properties ", function() {
+				return response.should.eventually.eql( {
+					id: 2,
+					parentId: 1,
+					title: "child",
+					grandChildren: [
+						{ id: 1 },
+						{ id: 2 },
+						{ id: 3 },
+						{ id: 4 },
+						{ id: 5 }
+					]
+				} );
+			} );
+		} );
+
+		describe( "when rendering action with embedded resources, with an empty array, and not using hal", function() {
+			var response;
+			var data = {
+				id: 2,
+				parentId: 1,
+				title: "child",
+				grandChildren: []
+			};
+			var envelope = {
+				user: {
+					name: "Evenly"
+				}
+			};
+			before( function() {
+				var fn1 = HyperResource.resourceGenerator( resources, { urlPrefix: "/test", apiPrefix: "/api" } );
+				response = fn1( "child", "self", envelope, data, "", undefined, undefined, false );
+			} );
+
+			it( "should still render an empty array at the top-level", function() {
+				return response.should.eventually.eql( {
+					id: 2,
+					parentId: 1,
+					title: "child",
+					grandChildren: []
+				} );
+			} );
+		} );
 	} );
 
 	describe( "when rendering options including children and skipping auth check", function() {

--- a/src/hyperResource.js
+++ b/src/hyperResource.js
@@ -363,7 +363,7 @@ function resourceGenerator( state, envelope, data, parentUrl, originUrl, originM
 			}
 			if ( embed ) {
 				embed.then( function( child ) {
-					if ( !_.isEmpty( child ) ) {
+					if ( !useHal || !_.isEmpty( child ) ) {
 						eAcc[ childName ] = child;
 					}
 				} );


### PR DESCRIPTION
When using `application/json` against a resource that uses embedded resources, empty arrays are not being rendered in the response for those embedded resources. For example, if `accounts` was an embedded resource, and the response returned `accounts: []`, this was being stripped from the response.