### PR TITLE
Make Middleware Groot Again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.6.x
 
+### 0.6.3
+ * Add support for preInit call to configuration to allow pre-empting addition of hyped middelware
+
 ### 0.6.2
  * Support for "hoisting" child resource actions to parent's hypermedia
  * Add support for versioning action handles

--- a/README.md
+++ b/README.md
@@ -357,6 +357,22 @@ This example will add middleware to `autohost` that extends the envelope to inte
 
 	Note: this approach only works with Autohost 0.4.0 or greater.
 
+
+#### PreInit
+There may be times where you need to add routes or middleware that pre-empt `hyped`'s. To do this, you can provide a `preInit` property in the configuration block (second argument to `createHost`). This function will be passed a handle to autohost and should either return a promise or invoke a callback when its finished.
+
+```javascript
+{
+	preInit: function( host, cb ) {
+		host.http.middleware( "/", function( req, res, next ) {
+			// this would get called before all other middleware
+			// and for every request
+			next();
+		}, "global" );
+	}
+}
+```
+
 __index.js__
 ```javascript
 var autohost = require( "autohost" );

--- a/spec/integration/autohost.spec.js
+++ b/spec/integration/autohost.spec.js
@@ -581,4 +581,68 @@ describe( "Autohost Integration", function() {
 			host.stop();
 		} );
 	} );
+
+	describe( "with preInit as callback", function() {
+		var hyped, host, globalCalled;
+		before( function( done ) {
+			hyped = require( "../../src/index.js" )( true, true );
+			host = hyped.createHost( autohost, {
+				resources: "./spec/ah",
+				apiPrefix: "",
+				preInit: function( host, callback ) {
+					host.http.middleware( "/", function( req, res, next ) {
+						globalCalled = true;
+						next();
+					}, "global" );
+					callback();
+				}
+			}, function() {
+					host.start();
+					done();
+				} );
+		} );
+
+		it( "should invoke global middleware added during preInit", function( done ) {
+			request( "http://localhost:8800/board/100", function( err, res ) {
+				globalCalled.should.equal( true );
+				done();
+			} );
+		} );
+
+		after( function() {
+			host.stop();
+		} );
+	} );
+
+	describe( "with preInit as promise", function() {
+		var hyped, host, globalCalled;
+		before( function( done ) {
+			hyped = require( "../../src/index.js" )( true, true );
+			host = hyped.createHost( autohost, {
+				resources: "./spec/ah",
+				apiPrefix: "",
+				preInit: function( host ) {
+					host.http.middleware( "/", function( req, res, next ) {
+						globalCalled = true;
+						next();
+					}, "global" );
+					return when.resolve();
+				}
+			}, function() {
+					host.start();
+					done();
+				} );
+		} );
+
+		it( "should invoke global middleware added during preInit", function( done ) {
+			request( "http://localhost:8800/board/100", function( err, res ) {
+				globalCalled.should.equal( true );
+				done();
+			} );
+		} );
+
+		after( function() {
+			host.stop();
+		} );
+	} );
 } );

--- a/src/index.js
+++ b/src/index.js
@@ -75,16 +75,27 @@ function createHost( state, autohost, config, done ) {
 	config.noOptions = true;
 	config.urlStrategy = state.urlStrategy;
 	var host = autohost( config );
-	state.setupMiddleware( host );
-	var subscription;
-	subscription = host.onResources( function( resources ) {
-		state.addResources( resources );
-		addResourceMiddleware( state, host );
-		subscription.unsubscribe();
-		if ( done ) {
-			done();
+	var preInit = config.preInit;
+	function callback() {
+		state.setupMiddleware( host );
+		var subscription;
+		subscription = host.onResources( function( resources ) {
+			state.addResources( resources );
+			addResourceMiddleware( state, host );
+			subscription.unsubscribe();
+			if ( done ) {
+				done();
+			}
+		} );
+	}
+	if ( preInit ) {
+		var result = preInit( host, callback );
+		if ( result && result.then ) {
+			result.then( callback );
 		}
-	} );
+	} else {
+		callback();
+	}
 	return host;
 }
 


### PR DESCRIPTION
Allows services to add a `preInit` call as part of config that will allow them to do register routes or middleware before hyped.